### PR TITLE
Husky and lint-staged tools integrated and configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.vscode/

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,8 @@
+const tasks = arr => arr.join(" && ");
+
+module.exports = {
+  hooks: {
+    "pre-commit": tasks(["lint-staged"]),
+    "pre-push": tasks(["yarn test:unit"])
+  }
+};

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "*.{js,vue,ts}": ["cross-env NODE_ENV=production eslint --fix", "git add"]
+};

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "New theme for Vue Storefront based on Storefront UI",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "cross-env NODE_ENV=production eslint --ext .js,.vue ./ --fix",
+    "test:unit": "echo \"No test specified yet\" && exit 0",
+    "lint": "cross-env NODE_ENV=production eslint --ext .js,.vue --fix ./",
     "dev": "cd ../../../ && yarn dev"
   },
   "license": "MIT",
@@ -28,6 +28,8 @@
     "eslint-loader": "^3.0.2",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-vue": "^6.0.1",
+    "husky": "^3.1.0",
+    "lint-staged": "^9.5.0",
     "prettier": "^1.19.1"
   }
 }


### PR DESCRIPTION
Closes #18 

Husky and lint-staged tools have been integrated and configured similarly like in `vue-storefront` repo. The only difference is that in `vsf-capybara` lint-staged tries to automatically fix problems and then it adds modified files again to git index.

The `test` script has been renamed to `test:unit` to match with `vue-storefront` repo and because in `vsf-capybara` there are not tests yet it returns success code 0 to be able to pass `pre-push` git hook (called by just installed Husky), which calls `yarn test:unit` :wink:

In screenshot below it can be seen that an attempt to commit a change with `console.log()` at line 34 is rejected by Husky which calls ESLint in `production` mode, where `console` and `debugger` commands are not permitted.

![husky-is-working](https://user-images.githubusercontent.com/56868128/70225541-82a61880-174f-11ea-905b-51d5a39a19ee.png)
