### PR TITLE
storefront-ui@develop branch integrated

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@
 * Update TypeScript compiler option in `compilerOptions.paths.theme/*` from default theme `["src/themes/default/*"]` to brand new `capybara` theme: `["src/themes/capybara/*"]`
 * Currently `storefront-ui` library is linked and used from its `develop` branch rather than from official releases to be able to get all fixes and new brilliant features as soon as possible. In order to make it possible `sfui` script has been introduced in `vsf-capybara`. **Every time `storefront-ui` is updated then `sfui` script has to be called.**
 * Download all dependencies and start dev server: `lerna bootstrap && lerna run sfui && yarn dev`
+* In order to fetch new commits from `storefront-ui` just call `yarn workspace @vue-storefront/theme-capybara upgrade https://github.com/DivanteLtd/storefront-ui#develop` (and then call `sfui` script as well).

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@
 * Configure `vsf-capybara` repo as a git submodule in theme path of your `vue-storefront` workspace and track `master` branch: `git submodule add -b master https://github.com/DivanteLtd/vsf-capybara src/themes/capybara`
 * Fetch all the data: `git submodule update --init --remote`
 * Update `theme` property in your local configuration in `config/local.json` file: `"@vue-storefront/theme-capybara"`
-* Download all dependencies and start dev server: `lerna bootstrap && yarn && yarn dev`
+* Update TypeScript compiler option in `compilerOptions.paths.theme/*` from default theme `["src/themes/default/*"]` to brand new `capybara` theme: `["src/themes/capybara/*"]`
+* Currently `storefront-ui` library is linked and used from its `develop` branch rather than from official releases to be able to get all fixes and new brilliant features as soon as possible. In order to make it possible `sfui` script has been introduced in `vsf-capybara`. **Every time `storefront-ui` is updated then `sfui` script has to be called.**
+* Download all dependencies and start dev server: `lerna bootstrap && lerna run sfui && yarn dev`

--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@
 * Update `theme` property in your local configuration in `config/local.json` file: `"@vue-storefront/theme-capybara"`
 * Update TypeScript compiler option in `compilerOptions.paths.theme/*` from default theme `["src/themes/default/*"]` to brand new `capybara` theme: `["src/themes/capybara/*"]`
 * Currently `storefront-ui` library is linked and used from its `develop` branch rather than from official releases to be able to get all fixes and new brilliant features as soon as possible. In order to make it possible `sfui` script has been introduced in `vsf-capybara`. **Every time `storefront-ui` is updated then `sfui` script has to be called.**
-* Download all dependencies and start dev server: `lerna bootstrap && lerna run sfui && yarn dev`
-* In order to fetch new commits from `storefront-ui` just call `yarn workspace @vue-storefront/theme-capybara upgrade https://github.com/DivanteLtd/storefront-ui#develop` (and then call `sfui` script as well).
+* Download all dependencies and start dev server: `lerna bootstrap && lerna run sfui:upgrade && yarn dev`
+* In order to just fetch new commits from `storefront-ui` from `develop` branch just call `lerna run sfui:upgrade`.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "cross-env NODE_ENV=production eslint --ext .js,.vue ./ --fix",
-    "dev": "cd ../../../ && yarn dev"
+    "dev": "cd ../../../ && yarn dev",
+    "sfui": "cd ../../../node_modules/@storefront-ui/vue/packages/vue && yarn && yarn postinstall"
   },
   "license": "MIT",
   "dependencies": {
+    "@storefront-ui/vue": "https://github.com/DivanteLtd/storefront-ui#develop",
     "body-scroll-lock": "^2.6.4",
     "vue": "^2.6.6",
     "vue-carousel": "^0.6.9",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "cross-env NODE_ENV=production eslint --ext .js,.vue ./ --fix",
     "dev": "cd ../../../ && yarn dev",
-    "sfui": "cd ../../../node_modules/@storefront-ui/vue/packages/vue && yarn && yarn postinstall"
+    "sfui:prepare": "cd ../../../node_modules/@storefront-ui/vue/packages/vue && yarn",
+    "sfui:upgrade": "yarn upgrade https://github.com/DivanteLtd/storefront-ui#develop && yarn sfui:prepare"
   },
   "license": "MIT",
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,15 @@
-// You can extend default webpack build here. Read more on docs: https://github.com/DivanteLtd/vue-storefront/blob/master/docs/guide/core-themes/webpack.md
+const merge = require("webpack-merge");
+
+// You can extend default webpack build here.
+// Read more in docs: https://github.com/DivanteLtd/vue-storefront/blob/master/docs/guide/core-themes/webpack.md
 module.exports = function(config) {
-  return config;
+  return merge(config, {
+    default: {
+      resolve: {
+        alias: {
+          "@storefront-ui/vue": "@storefront-ui/vue/packages/vue"
+        }
+      }
+    }
+  });
 };


### PR DESCRIPTION
Closes #10 

There were 2 options how to integrate `storefront-ui` library with `vsf-capybara`:

- using its default (official) releases - easy and not challenging enough approach 😉 
- stick with `develop` branch, which is updated much more often - it is a little bit more complex since `storefront-ui` uses own workspaces and after fetching it directly from GitHub via URL (rather than using package name) it is not ready to be used.

As I heard from `storefront-ui` team it is better from development point of view to choose latter approach and use their lib on `develop` branch. Due to that fact new `sfui` script has been introduced to prepare `storefront-ui` library and to be able to import its components into new theme. Additionally, minor webpack change also has to be introduced to properly resolve paths to development version of `storefront-ui`.

Integration of `storefront-ui` library on its `develop` branch has been successfully finished and now `vsf-capybara` can utilize brand new components much faster than in "slow ring" of official releases.

As a proof that it works I added 5 buttons on the Home page...

![storefront-ui-integrated](https://user-images.githubusercontent.com/56868128/70324189-21557680-182f-11ea-97a2-32be5cb41f94.png)

The `SfDivider` and `SfCircleIcon` have been used to prepare above screenshot.