### PR TITLE
update Header and related components

### DIFF
--- a/components/core/Logo.vue
+++ b/components/core/Logo.vue
@@ -1,14 +1,10 @@
 <template>
-  <router-link
-    :to="localizedRoute('/')"
-    :title="$t('Home Page')"
-    class="no-underline inline-flex"
-  >
-    <img
-      :width="width"
-      :height="height"
+  <router-link :to="localizedRoute('/')" :title="$t('Home Page')" class="logo">
+    <SfImage
+      :style="{ width, height }"
       src="/assets/logo.svg"
       :alt="$t(defaultTitle)"
+      class="sf-header__logo no-underline"
     />
   </router-link>
 </template>
@@ -16,8 +12,11 @@
 <script>
 import config from "config";
 import { currentStoreView } from "@vue-storefront/core/lib/multistore";
+import { SfImage } from "@storefront-ui/vue";
+import get from "lodash-es/get";
 
 export default {
+  components: { SfImage },
   props: {
     width: {
       type: [String, Number],
@@ -28,13 +27,16 @@ export default {
       required: true
     }
   },
-  data() {
-    const storeView = currentStoreView();
-    return {
-      defaultTitle: storeView.seo.defaultTitle
-        ? storeView.seo.defaultTitle
-        : config.seo.defaultTitle
-    };
+  computed: {
+    defaultTitle() {
+      const storeView = currentStoreView();
+      return get(storeView, "seo.defaultTitle", config.seo.defaultTitle);
+    }
   }
 };
 </script>
+<style lang="scss" scoped>
+.logo {
+  display: inline-flex;
+}
+</style>

--- a/components/core/Logo.vue
+++ b/components/core/Logo.vue
@@ -15,6 +15,8 @@ import { currentStoreView } from "@vue-storefront/core/lib/multistore";
 import { SfImage } from "@storefront-ui/vue";
 import get from "lodash-es/get";
 
+const storeView = currentStoreView();
+
 export default {
   components: { SfImage },
   props: {
@@ -29,7 +31,6 @@ export default {
   },
   computed: {
     defaultTitle() {
-      const storeView = currentStoreView();
       return get(storeView, "seo.defaultTitle", config.seo.defaultTitle);
     }
   }

--- a/components/core/blocks/Header/AccountIcon.vue
+++ b/components/core/blocks/Header/AccountIcon.vue
@@ -1,148 +1,27 @@
 <template>
-  <div
-    class="inline-flex relative dropdown"
-    data-testid="accountButton"
-    tabindex="0"
+  <SfCircleIcon
+    icon="profile"
+    icon-size="20px"
+    icon-color="black"
+    class="sf-header__icon"
     role="button"
-    :aria-label="$t('Open my account')"
-    @click.self="
-      goToAccount();
-      showMenu = true;
-    "
-    @keyup.enter="goToAccount"
-    @mouseover="showMenu = true"
-    @mouseout="showMenu = false"
-  >
-    <button type="button" class="bg-cl-transparent brdr-none p0">
-      <i class="material-icons block">account_circle</i>
-    </button>
-
-    <no-ssr>
-      <div
-        v-show="currentUser"
-        :class="[
-          'dropdown-content bg-cl-primary align-left sans-serif lh20 weight-400',
-          !showMenu ? 'dropdown-content__hidden' : ''
-        ]"
-      >
-        <div class="py5">
-          <div
-            v-for="(page, index) in navigation"
-            :key="index"
-            @click="notify(page.title)"
-          >
-            <router-link
-              class="no-underline block py10 px15"
-              :to="localizedRoute(page.link)"
-              @click.native="showMenu = false"
-            >
-              {{ page.title }}
-            </router-link>
-          </div>
-        </div>
-        <div class="py5 brdr-top-1 brdr-cl-bg-secondary">
-          <a
-            href="#"
-            class="no-underline block py10 px15"
-            @click.prevent="logout"
-          >
-            {{ $t("Logout") }}
-          </a>
-        </div>
-      </div>
-    </no-ssr>
-  </div>
+    aria-label="account"
+    :class="{ 'sf-header__icon--is-active': isLoggedIn }"
+    :aria-pressed="isLoggedIn ? 'true' : 'false'"
+    @click="goToAccount"
+  />
 </template>
 
 <script>
-import NoSSR from "vue-no-ssr";
+import { SfCircleIcon } from "@storefront-ui/vue";
 import AccountIcon from "@vue-storefront/core/compatibility/components/blocks/Header/AccountIcon";
+import { mapGetters } from "vuex";
 
 export default {
-  components: {
-    "no-ssr": NoSSR
-  },
+  components: { SfCircleIcon },
   mixins: [AccountIcon],
-  data() {
-    return {
-      showMenu: false,
-      navigation: [
-        { title: this.$t("My profile"), link: "/my-account" },
-        {
-          title: this.$t("My shipping details"),
-          link: "/my-account/shipping-details"
-        },
-        { title: this.$t("My newsletter"), link: "/my-account/newsletter" },
-        { title: this.$t("My orders"), link: "/my-account/orders" },
-        { title: this.$t("My loyalty card"), link: "#" },
-        { title: this.$t("My product reviews"), link: "#" },
-        {
-          title: this.$t("My Recently viewed products"),
-          link: "/my-account/recently-viewed"
-        }
-      ]
-    };
-  },
-  methods: {
-    notify(title) {
-      if (title === "My loyalty card" || title === "My product reviews") {
-        this.$store.dispatch("notification/spawnNotification", {
-          type: "warning",
-          message: this.$t(
-            "This feature is not implemented yet! Please take a look at https://github.com/DivanteLtd/vue-storefront/issues for our Roadmap!"
-          ),
-          action1: { label: this.$t("OK") }
-        });
-      }
-    }
+  computed: {
+    ...mapGetters("user", ["isLoggedIn"])
   }
 };
 </script>
-
-<style lang="scss" scoped>
-@import "~theme/css/base/global_vars";
-@import "~theme/css/variables/colors";
-@import "~theme/css/helpers/functions/color";
-$color-icon-hover: color(secondary, $colors-background);
-
-.dropdown {
-  button {
-    pointer-events: none;
-  }
-
-  .dropdown-content {
-    display: none;
-    position: absolute;
-    right: 0;
-    top: 100%;
-    width: 160px;
-    z-index: 1;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  }
-
-  a {
-    opacity: 0.6;
-
-    &:hover,
-    &:focus {
-      background-color: $color-icon-hover;
-      opacity: 1;
-    }
-  }
-
-  @media (min-width: 768px) {
-    &:hover .dropdown-content:not(.dropdown-content__hidden),
-    &:focus .dropdown-content:not(.dropdown-content__hidden) {
-      display: block;
-    }
-
-    &:focus-within {
-      background-color: $color-icon-hover;
-      opacity: 1;
-      .dropdown-content:not(.dropdown-content__hidden) {
-        display: block;
-      }
-    }
-  }
-}
-</style>

--- a/components/core/blocks/Header/Header.vue
+++ b/components/core/blocks/Header/Header.vue
@@ -1,203 +1,86 @@
 <template>
   <div class="header">
-    <header
-      class="fixed w-100 brdr-bottom-1 bg-cl-primary brdr-cl-secondary"
-      :class="{ 'is-visible': navVisible }"
-    >
-      <div class="container px15">
-        <div
-          v-if="!isCheckoutPage || isThankYouPage"
-          class="row between-xs middle-xs"
+    <SfHeader :active-icon="activeIcon">
+      <template #logo>
+        <Logo width="41px" height="41px" />
+      </template>
+      <template #navigation>
+        <router-link
+          v-for="category in categories"
+          :key="category.id"
+          class="no-underline"
+          :to="categoryLink(category)"
         >
-          <div class="col-md-4 col-xs-2 middle-xs">
-            <div>
-              <hamburger-icon class="p15 icon bg-cl-secondary pointer" />
-            </div>
-          </div>
-          <div class="col-xs-2 visible-xs">
-            <search-icon class="p15 icon pointer" />
-          </div>
-          <div class="col-md-4 col-xs-4 center-xs pt5">
-            <div>
-              <logo width="auto" height="41px" />
-            </div>
-          </div>
-          <div class="col-xs-2 visible-xs">
-            <wishlist-icon class="p15 icon pointer" />
-          </div>
-          <div class="col-md-4 col-xs-2 end-xs">
-            <div class="inline-flex right-icons">
-              <search-icon class="p15 icon hidden-xs pointer" />
-              <wishlist-icon class="p15 icon hidden-xs pointer" />
-              <compare-icon class="p15 icon hidden-xs pointer" />
-              <microcart-icon class="p15 icon pointer" />
-              <account-icon class="p15 icon hidden-xs pointer" />
-            </div>
-          </div>
+          <SfHeaderNavigationItem>{{ category.name }}</SfHeaderNavigationItem>
+        </router-link>
+      </template>
+      <template #search><div class="hidden"></div></template>
+      <template #header-icons>
+        <div class="sf-header__icons ml-auto">
+          <AccountIcon />
+          <WishlistIcon />
+          <MicrocartIcon />
         </div>
-        <div
-          v-if="isCheckoutPage && !isThankYouPage"
-          class="row between-xs middle-xs px15 py5"
-        >
-          <div class="col-xs-5 col-md-3 middle-xs">
-            <div>
-              <router-link :to="localizedRoute('/')" class="cl-tertiary links">
-                {{ $t("Return to shopping") }}
-              </router-link>
-            </div>
-          </div>
-          <div class="col-xs-2 col-md-6 center-xs">
-            <logo width="auto" height="41px" />
-          </div>
-          <div class="col-xs-5 col-md-3 end-xs">
-            <div>
-              <a
-                v-if="!currentUser"
-                href="#"
-                class="cl-tertiary links"
-                @click.prevent="gotoAccount"
-                >{{ $t("Login to your account") }}</a
-              >
-              <span v-else>{{
-                $t("You are logged in as {firstname}", currentUser)
-              }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </header>
-    <div class="header-placeholder" />
+      </template>
+    </SfHeader>
   </div>
 </template>
 
 <script>
-import { mapState } from "vuex";
-import CurrentPage from "theme/mixins/currentPage";
-import AccountIcon from "theme/components/core/blocks/Header/AccountIcon";
-import CompareIcon from "theme/components/core/blocks/Header/CompareIcon";
-import HamburgerIcon from "theme/components/core/blocks/Header/HamburgerIcon";
+import { SfHeader } from "@storefront-ui/vue";
 import Logo from "theme/components/core/Logo";
-import MicrocartIcon from "theme/components/core/blocks/Header/MicrocartIcon";
-import SearchIcon from "theme/components/core/blocks/Header/SearchIcon";
+import AccountIcon from "theme/components/core/blocks/Header/AccountIcon";
 import WishlistIcon from "theme/components/core/blocks/Header/WishlistIcon";
+import MicrocartIcon from "theme/components/core/blocks/Header/MicrocartIcon";
+import { mapGetters } from "vuex";
+import { formatCategoryLink } from "@vue-storefront/core/modules/url/helpers";
 
 export default {
   name: "Header",
   components: {
-    AccountIcon,
-    CompareIcon,
-    HamburgerIcon,
+    SfHeader,
     Logo,
-    MicrocartIcon,
-    SearchIcon,
-    WishlistIcon
-  },
-  mixins: [CurrentPage],
-  data() {
-    return {
-      navVisible: true,
-      isScrolling: false,
-      scrollTop: 0,
-      lastScrollTop: 0,
-      navbarHeight: 54
-    };
+    AccountIcon,
+    WishlistIcon,
+    MicrocartIcon
   },
   computed: {
-    ...mapState({
-      isOpenLogin: state => state.ui.signUp,
-      currentUser: state => state.user.current
-    }),
-    isThankYouPage() {
-      return this.$store.state.checkout.isThankYouPage
-        ? this.$store.state.checkout.isThankYouPage
-        : false;
+    ...mapGetters("category", ["getCategories"]),
+    ...mapGetters("user", ["isLoggedIn"]),
+    activeIcon() {
+      return this.isLoggedIn ? "account" : "";
+    },
+    categories() {
+      return this.getCategories.filter(
+        category => category.is_active && category.children_count > 0
+      );
     }
   },
-  beforeMount() {
-    window.addEventListener(
-      "scroll",
-      () => {
-        this.isScrolling = true;
-      },
-      { passive: true }
-    );
-
-    setInterval(() => {
-      if (this.isScrolling) {
-        this.hasScrolled();
-        this.isScrolling = false;
-      }
-    }, 250);
-  },
   methods: {
-    gotoAccount() {
-      this.$bus.$emit("modal-toggle", "modal-signup");
-    },
-    hasScrolled() {
-      this.scrollTop = window.scrollY;
-      if (
-        this.scrollTop > this.lastScrollTop &&
-        this.scrollTop > this.navbarHeight
-      ) {
-        this.navVisible = false;
-      } else {
-        this.navVisible = true;
-      }
-      this.lastScrollTop = this.scrollTop;
+    categoryLink(category) {
+      return formatCategoryLink(category);
     }
   }
 };
 </script>
 
 <style lang="scss" scoped>
-@import "~theme/css/variables/colors";
-@import "~theme/css/helpers/functions/color";
-$color-icon-hover: color(secondary, $colors-background);
+@import "~@storefront-ui/shared/styles/_variables.scss";
 
-header {
-  height: 54px;
-  top: -55px;
-  z-index: 1;
-  transition: top 0.2s ease-in-out;
-  &.is-visible {
-    top: 0;
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
   }
 }
-.icon {
-  opacity: 0.6;
-  &:hover,
-  &:focus {
-    background-color: $color-icon-hover;
-    opacity: 1;
-  }
-}
-.right-icons {
-  //for edge
-  float: right;
-}
-.header-placeholder {
-  height: 54px;
-}
-.links {
-  text-decoration: underline;
-}
-@media (max-width: 767px) {
-  .row.middle-xs {
-    margin: 0 -15px;
 
-    &.py5 {
-      margin: 0;
-    }
+.header {
+  box-sizing: border-box;
+  @include for-desktop {
+    max-width: 1240px;
+    margin: auto;
   }
-  .col-xs-2:first-of-type {
-    padding-left: 0;
-  }
-  .col-xs-2:last-of-type {
-    padding-right: 0;
-  }
-  a,
-  span {
-    font-size: 12px;
-  }
+}
+.ml-auto {
+  margin-left: auto;
 }
 </style>

--- a/components/core/blocks/Header/Header.vue
+++ b/components/core/blocks/Header/Header.vue
@@ -17,6 +17,7 @@
       <template #search><div class="hidden"></div></template>
       <template #header-icons>
         <div class="sf-header__icons ml-auto">
+          <SearchIcon />
           <AccountIcon />
           <WishlistIcon />
           <MicrocartIcon />
@@ -29,6 +30,7 @@
 <script>
 import { SfHeader } from "@storefront-ui/vue";
 import Logo from "theme/components/core/Logo";
+import SearchIcon from "theme/components/core/blocks/Header/SearchIcon";
 import AccountIcon from "theme/components/core/blocks/Header/AccountIcon";
 import WishlistIcon from "theme/components/core/blocks/Header/WishlistIcon";
 import MicrocartIcon from "theme/components/core/blocks/Header/MicrocartIcon";
@@ -42,7 +44,8 @@ export default {
     Logo,
     AccountIcon,
     WishlistIcon,
-    MicrocartIcon
+    MicrocartIcon,
+    SearchIcon
   },
   computed: {
     ...mapGetters("category", ["getCategories"]),

--- a/components/core/blocks/Header/MicrocartIcon.vue
+++ b/components/core/blocks/Header/MicrocartIcon.vue
@@ -1,38 +1,30 @@
 <template>
-  <button
-    type="button"
-    class="relative bg-cl-transparent brdr-none inline-flex"
-    data-testid="openMicrocart"
-    :aria-label="$t('Open microcart')"
-    @click="openMicrocart"
-  >
-    <i class="material-icons">shopping_cart</i>
-    <span
-      v-cloak
-      v-show="totalQuantity"
-      class="minicart-count absolute flex center-xs middle-xs border-box py0 px2 h6 lh16 weight-700 cl-white bg-cl-silver"
-      data-testid="minicartCount"
-    >
-      {{ totalQuantity }}
-    </span>
-  </button>
+  <div class="cart-icon">
+    <SfCircleIcon
+      icon="empty_cart"
+      icon-size="20px"
+      icon-color="black"
+      class="sf-header__icon"
+      role="button"
+      :aria-label="$t('Open microcart')"
+      @click="openMicrocart"
+    />
+    <SfBadge v-show="totalQuantity" class="cart-icon__badge"
+      >{{ totalQuantity }}
+    </SfBadge>
+  </div>
 </template>
 
 <script>
 import { mapGetters, mapActions } from "vuex";
+import { SfCircleIcon, SfBadge } from "@storefront-ui/vue";
 
 export default {
+  components: { SfCircleIcon, SfBadge },
   computed: {
     ...mapGetters({
       totalQuantity: "cart/getItemsTotalQuantity"
     })
-  },
-  mounted() {
-    document.addEventListener("visibilitychange", () => {
-      if (!document.hidden) {
-        this.$store.dispatch("cart/load");
-      }
-    });
   },
   methods: {
     ...mapActions({
@@ -42,12 +34,18 @@ export default {
 };
 </script>
 
-<style scoped>
-.minicart-count {
-  top: 7px;
-  left: 50%;
-  min-width: 16px;
-  min-height: 16px;
-  border-radius: 10px;
+<style lang="scss" scoped>
+.cart-icon {
+  position: relative;
+  &__badge {
+    position: absolute;
+    bottom: 2.2em;
+    left: 4.2em;
+    font-size: 0.6em;
+    padding: 0.3em 0;
+    border-radius: 100%;
+    width: 2.2em;
+    min-height: 2.2em;
+  }
 }
 </style>

--- a/components/core/blocks/Header/SearchIcon.vue
+++ b/components/core/blocks/Header/SearchIcon.vue
@@ -1,19 +1,23 @@
 <template>
-  <button
-    type="button"
+  <SfCircleIcon
+    icon="search"
+    icon-size="20px"
+    icon-color="black"
+    class="sf-header__icon"
+    role="button"
     :aria-label="$t('Open search panel')"
-    class="bg-cl-transparent brdr-none inline-flex"
-    data-testid="openSearchPanel"
     @click="toggleSearchpanel"
-  >
-    <i class="material-icons">search</i>
-  </button>
+  />
 </template>
 
 <script>
+import { SfCircleIcon } from "@storefront-ui/vue";
 import SearchIcon from "@vue-storefront/core/compatibility/components/blocks/Header/SearchIcon";
 
 export default {
+  components: {
+    SfCircleIcon
+  },
   mixins: [SearchIcon]
 };
 </script>

--- a/components/core/blocks/Header/WishlistIcon.vue
+++ b/components/core/blocks/Header/WishlistIcon.vue
@@ -1,35 +1,42 @@
 <template>
-  <button
-    type="button"
-    class="inline-flex bg-cl-transparent brdr-none relative"
-    :aria-label="$t('Open wishlist')"
-    @click="toggleWishlistPanel"
-  >
-    <i class="material-icons">favorite_border</i>
-    <span
-      v-cloak
-      v-show="getWishlistItemsCount"
-      class="whishlist-count absolute flex center-xs middle-xs border-box py0 px2 h6 lh16 weight-700 cl-white bg-cl-silver"
-    >
-      {{ getWishlistItemsCount }}
-    </span>
-  </button>
+  <div class="wishlist-icon">
+    <SfCircleIcon
+      icon="heart"
+      icon-size="20px"
+      icon-color="black"
+      class="sf-header__icon"
+      role="button"
+      aria-label="wishlist"
+      @click="toggleWishlistPanel"
+    />
+    <SfBadge v-show="getWishlistItemsCount" class="wishlist-icon__badge"
+      >{{ getWishlistItemsCount }}
+    </SfBadge>
+  </div>
 </template>
 
 <script>
 import WishlistIcon from "@vue-storefront/core/compatibility/components/blocks/Header/WishlistIcon";
+import { SfCircleIcon, SfBadge } from "@storefront-ui/vue";
 
 export default {
+  components: { SfCircleIcon, SfBadge },
   mixins: [WishlistIcon]
 };
 </script>
 
-<style scoped>
-.whishlist-count {
-  top: 7px;
-  left: 50%;
-  min-width: 16px;
-  min-height: 16px;
-  border-radius: 10px;
+<style lang="scss" scoped>
+.wishlist-icon {
+  position: relative;
+  &__badge {
+    position: absolute;
+    bottom: 2.2em;
+    left: 4.2em;
+    font-size: 0.6em;
+    padding: 0.3em 0;
+    border-radius: 100%;
+    width: 2.2em;
+    min-height: 2.2em;
+  }
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@storefront-ui/vue": "^0.3.5",
+    "@storefront-ui/vue": "^0.4.0",
     "body-scroll-lock": "^2.6.4",
     "vue": "^2.6.6",
     "vue-carousel": "^0.6.9",


### PR DESCRIPTION
Closes #43

In task description there is info `Wish list icon is visible but does not contain any logic.`. I left logic that opens this sidebar, because it is just one method that we will change/replace in future.

1.How about moving new component to some other new folders? We use `/components/core/*` or `components/theme/*`, but this is confusing because there are new and old components. And also I never understood this separation `core` / `theme` because 90% of components are in `core` and you will change components in `core` anyway if you need to. wdyt? If there is some good reason to have such a separation then we can make `core_temp` and `theme_temp` for migration time.

2.Do we want to use anything from `src/themes/capybara/css`? there are some utility css, grid. Maybe we should migrate only what's needed to `src/themes/capybara/css_temp` and then remove `src/themes/capybara/css`?

![Zrzut ekranu z 2020-01-07 14-29-17](https://user-images.githubusercontent.com/42383376/71898647-21140800-315a-11ea-87de-b85956a368ea.png)
