### PR TITLE
Feature/48

### DIFF
--- a/components/atoms/a-product-price.vue
+++ b/components/atoms/a-product-price.vue
@@ -1,9 +1,14 @@
 <template>
   <SfPrice
-    regular="$50.00"
+    :regular="renderPrice.regular"
+    :special="renderPrice.special"
   />
 </template>
 <script>
+import { price } from '@vue-storefront/core/filters';
+import { getCustomOptionValues, getCustomOptionPriceDelta } from '@vue-storefront/core/modules/catalog/helpers/customOption'
+import { getBundleOptionsValues, getBundleOptionPrice } from '@vue-storefront/core/modules/catalog/helpers/bundleOptions'
+import get from 'lodash-es/get'
 import { SfPrice } from '@storefront-ui/vue';
 export default {
   name: 'AProductPrice',
@@ -14,6 +19,58 @@ export default {
     product: {
       type: Object,
       default: () => ({})
+    },
+    customOptions: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  computed: {
+    bundleOptionsPrice () {
+      const allBundeOptions = this.product.bundle_options || []
+      const selectedBundleOptions = Object.values(get(this.product, 'product_option.extension_attributes.bundle_options', {}))
+      const price = getBundleOptionPrice(
+        getBundleOptionsValues(selectedBundleOptions, allBundeOptions)
+      )
+      return price
+    },
+    customOptionsPriceDelta () {
+      const priceDelta = getCustomOptionPriceDelta(
+        getCustomOptionValues(Object.values(this.customOptions), this.product.custom_options),
+        this.product
+      )
+
+      return priceDelta
+    },
+    price () {
+      const special = (this.product.price_incl_tax + this.customOptionsPriceDelta.priceInclTax) * this.product.qty
+      const original = (this.product.original_price_incl_tax + this.customOptionsPriceDelta.priceInclTax) * this.product.qty
+      const defaultPrice = this.product.qty > 0
+        ? (this.product.price_incl_tax + this.customOptionsPriceDelta.priceInclTax) * this.product.qty
+        : this.product.price_incl_tax
+
+      if (this.bundleOptionsPrice.priceInclTax > 0) {
+        return {
+          special,
+          original,
+          default: this.bundleOptionsPrice.priceInclTax
+        }
+      }
+
+      return {
+        special,
+        original,
+        default: defaultPrice
+      }
+    },
+    isSpecialPrice () {
+      return this.product.special_price && this.product.price_incl_tax && this.product.original_price_incl_tax
+    },
+    renderPrice () {
+      return {
+        regular: this.isSpecialPrice ? price(this.price.original) : price(this.price.default),
+        special: this.isSpecialPrice ? price(this.price.special) : ''
+      }
     }
   }
 }

--- a/components/atoms/a-product-price.vue
+++ b/components/atoms/a-product-price.vue
@@ -1,0 +1,20 @@
+<template>
+  <SfPrice
+    regular="$50.00"
+  />
+</template>
+<script>
+import { SfPrice } from '@storefront-ui/vue';
+export default {
+  name: 'AProductPrice',
+  components: {
+    SfPrice
+  },
+  props: {
+    product: {
+      type: Object,
+      default: () => ({})
+    }
+  }
+}
+</script>

--- a/components/atoms/a-product-rating.vue
+++ b/components/atoms/a-product-rating.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="a-product-rating">
+    <SfRating :score="score" :max="max" />
+    <ATextAction class="a-product-rating__action">
+      <span class="a-product-rating__reviews desktop-only">
+        {{ $t("Read all {review} review", { review: review }) }}
+      </span>
+      <span class="a-product-rating__reviews mobile-only">
+        {{ `(${review})` }}
+      </span>
+    </ATextAction>
+  </div>
+</template>
+<script>
+import { SfRating } from '@storefront-ui/vue';
+import ATextAction from 'theme/components/atoms/a-text-action';
+export default {
+  components: {
+    SfRating,
+    ATextAction
+  },
+  props: {
+    score: {
+      type: Number,
+      default: 0,
+      reqiured: true
+    },
+    max: {
+      type: Number,
+      default: 0,
+      reqiured: true
+    },
+    review: {
+      type: Number,
+      default: 0
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+.a-product-rating {
+  display: flex;
+  margin-top: $spacer-big / 2;
+  @include for-desktop {
+    margin-left: auto;
+  }
+  &__reviews {
+    margin-left: 10px;
+    font-size: 0.75rem;
+  }
+  &__action {
+    margin: 0;
+    ::v-deep .sf-action {
+      line-height: 1;
+      padding-bottom: 5px;
+    }
+  }
+}
+</style>

--- a/components/atoms/a-text-action.vue
+++ b/components/atoms/a-text-action.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="a-text-action">
+    <button class="sf-action" @click="$emit('click')">
+      <slot>
+        {{ text }}
+      </slot>
+    </button>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ATextAction',
+  props: {
+    text: {
+      type: String,
+      default: ''
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+
+.a-text-action {
+  display: flex;
+  margin: $spacer-big 0 ($spacer-big / 2);
+}
+/* SfAction or SfButton modifier */
+.sf-action {
+  padding: 0;
+  border: 0;
+  outline: none;
+  background-color: transparent;
+  color: $c-text;
+  font-family: $body-font-family-secondary;
+  font-size: $font-size-regular-mobile;
+  font-weight: $body-font-weight-secondary;
+  line-height: 1.6;
+  text-decoration: underline;
+  cursor: pointer;
+  @include for-desktop {
+    font-size: $font-size-regular-desktop;
+  }
+}
+</style>

--- a/components/molecules/m-product-additional-info.vue
+++ b/components/molecules/m-product-additional-info.vue
@@ -1,0 +1,137 @@
+<template>
+  <SfTabs class="m-product-additional-info" :open-tab="2">
+    <SfTab title="Description">
+      <div>
+        <p>
+          The Karissa V-Neck Tee features a semi-fitted shape that's flattering
+          for every figure. You can hit the gym with confidence while it hugs
+          curves and hides common "problem" areas. Find stunning women's
+          cocktail dresses and party dresses.
+        </p>
+      </div>
+      <div class="m-product-additional-info__properties">
+        <SfProperty
+          v-for="(property, i) in properties"
+          :key="i"
+          class="m-product-additional-info__property"
+          :name="property.name"
+          :value="property.value"
+        />
+      </div>
+    </SfTab>
+    <SfTab title="Read reviews">
+      <SfReview
+        v-for="(review, i) in reviews"
+        :key="i"
+        class="m-product-additional-info__review"
+        :author="review.author"
+        :date="review.date"
+        :message="review.message"
+        :rating="review.rating"
+        :max-rating="5"
+      />
+    </SfTab>
+    <SfTab title="Additional Information">
+      <SfHeading
+        title="Brand"
+        :level="3"
+        class="sf-heading--no-underline sf-heading--left"
+      />
+      <p>
+        <u>Brand name</u> is the perfect pairing of quality and design. This
+        label creates major everyday vibes with its collection of modern
+        brooches, silver and gold jewellery, or clips it back with hair
+        accessories in geo styles.
+      </p>
+    </SfTab>
+  </SfTabs>
+</template>
+<script>
+import { SfProperty, SfHeading, SfTabs, SfReview } from '@storefront-ui/vue';
+export default {
+  components: {
+    SfProperty,
+    SfHeading,
+    SfTabs,
+    SfReview
+  },
+  data () {
+    return {
+      properties: [
+        {
+          name: 'Product Code',
+          value: '578902-00'
+        },
+        {
+          name: 'Category',
+          value: 'Pants'
+        },
+        {
+          name: 'Material',
+          value: 'Cotton'
+        },
+        {
+          name: 'Country',
+          value: 'Germany'
+        }
+      ],
+      reviews: [
+        {
+          author: 'Jane D.Smith',
+          date: 'April 2019',
+          message:
+            "I was looking for a bright light for the kitchen but wanted some item more modern than a strip light. this one is perfect, very bright and looks great. I can't comment on interlation as I had an electrition instal it. Would recommend",
+          rating: 4
+        },
+        {
+          author: 'Mari',
+          date: 'Jan 2018',
+          message:
+            'Excellent light output from this led fitting. Relatively easy to fix to the ceiling,but having two people makes it easier, to complete the installation. Unable to comment on reliability at this time, but I am hopeful of years of use with good light levels. Excellent light output from this led fitting. Relatively easy to fix to the ceiling,',
+          rating: 5
+        }
+      ]
+    };
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+
+.m-product-additional-info {
+  margin-top: $spacer-big;
+  @include for-desktop {
+    margin-top: 5 * $spacer-big;
+  }
+  p {
+    margin: 0;
+  }
+  &__properties {
+    margin-top: $spacer-big;
+  }
+  &__property {
+    padding: $spacer-small 0;
+  }
+  &__review {
+    padding-bottom: $spacer-big;
+    @include for-desktop {
+      padding-bottom: $spacer-extra-big;
+      border-bottom: 1px solid $c-light;
+    }
+    & + & {
+      padding-top: $spacer-extra-big;
+      border-top: 1px solid $c-light;
+      @include for-desktop {
+        border-top: 0;
+        padding-top: $spacer-extra-big;
+      }
+    }
+  }
+}
+</style>

--- a/components/molecules/m-product-call-to-action.vue
+++ b/components/molecules/m-product-call-to-action.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="m-product-call-to-action">
+    <SfAddToCart
+      v-model="qty"
+      :stock="stock"
+      :can-add-to-cart="stock > 0"
+      class="m-product-call-to-action__add-to-cart"
+    />
+    <ATextAction
+      class="m-product-call-to-action__text-action"
+      text="Save for later"
+    />
+    <ATextAction
+      class="m-product-call-to-action__text-action"
+      text="Add to compare"
+    />
+  </div>
+</template>
+<script>
+import { SfAddToCart } from '@storefront-ui/vue';
+import ATextAction from 'theme/components/atoms/a-text-action';
+export default {
+  name: 'MProductCallToAction',
+  components: {
+    SfAddToCart,
+    ATextAction
+  },
+  data () {
+    return {
+      qty: '1',
+      stock: 5
+    };
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+.m-product-call-to-action {
+  &__add-to-cart {
+    margin-top: 1.5rem;
+    @include for-desktop {
+      margin-top: $spacer-extra-big;
+    }
+  }
+  &__text-action {
+    @include for-desktop {
+      justify-content: flex-end;
+    }
+  }
+}
+</style>

--- a/components/molecules/m-product-carousel.vue
+++ b/components/molecules/m-product-carousel.vue
@@ -18,15 +18,15 @@
   </SfCarousel>
 </template>
 <script>
-import { mapGetters } from "vuex";
-import { SfProductCard, SfCarousel } from "@storefront-ui/vue";
-import { price, htmlDecode } from "@vue-storefront/core/filters";
-import config from "config";
-import { currentStoreView } from "@vue-storefront/core/lib/multistore";
-import { formatProductLink } from "@vue-storefront/core/modules/url/helpers";
-import { productThumbnailPath } from "@vue-storefront/core/helpers";
+import { mapGetters } from 'vuex';
+import { SfProductCard, SfCarousel } from '@storefront-ui/vue';
+import { price, htmlDecode } from '@vue-storefront/core/filters';
+import config from 'config';
+import { currentStoreView } from '@vue-storefront/core/lib/multistore';
+import { formatProductLink } from '@vue-storefront/core/modules/url/helpers';
+import { productThumbnailPath } from '@vue-storefront/core/helpers';
 export default {
-  name: "MProductCarousel",
+  name: 'MProductCarousel',
   components: {
     SfCarousel,
     SfProductCard
@@ -39,9 +39,9 @@ export default {
   },
   computed: {
     ...mapGetters({
-      isOnWishlist: "wishlist/isOnWishlist"
+      isOnWishlist: 'wishlist/isOnWishlist'
     }),
-    carouselProducts() {
+    carouselProducts () {
       return this.products.map(product => {
         return {
           data: product,
@@ -65,22 +65,22 @@ export default {
     }
   },
   methods: {
-    toggleWishlist(product) {
+    toggleWishlist (product) {
       const isProductOnWishlist = this.isOnWishlist(product);
       const message = isProductOnWishlist
-        ? "Product {productName} has been removed from wishlist!"
-        : "Product {productName} has been added to wishlist!";
+        ? 'Product {productName} has been removed from wishlist!'
+        : 'Product {productName} has been added to wishlist!';
       const action = isProductOnWishlist
-        ? "wishlist/removeItem"
-        : "wishlist/addItem";
+        ? 'wishlist/removeItem'
+        : 'wishlist/addItem';
 
       this.$store.dispatch(action, product);
       this.$store.dispatch(
-        "notification/spawnNotification",
+        'notification/spawnNotification',
         {
-          type: "success",
+          type: 'success',
           message: this.$t(message, { productName: product.name }),
-          action1: { label: this.$t("OK") }
+          action1: { label: this.$t('OK') }
         },
         { root: true }
       );

--- a/components/molecules/m-product-gallery.vue
+++ b/components/molecules/m-product-gallery.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="m-product-gallery">
+    <SfImage class="desktop-only" :src="variantImage" />
+    <SfImage
+      v-if="additionalImage"
+      class="desktop-only"
+      :src="additionalImage"
+    />
+    <SfGallery
+      ref="imageGallery"
+      class="m-product-gallery__mobile mobile-only"
+      :images="gallery"
+      :current="currentIndex + 1"
+      :slider-options="sliderOptions"
+    />
+  </div>
+</template>
+<script>
+import { SfGallery, SfImage } from '@storefront-ui/vue';
+import reduce from 'lodash-es/reduce';
+import map from 'lodash-es/map';
+import isEqual from 'lodash-es/isEqual';
+import { onlineHelper } from '@vue-storefront/core/helpers';
+export default {
+  name: 'MProductGallery',
+  components: {
+    SfGallery,
+    SfImage
+  },
+  props: {
+    gallery: {
+      type: Array,
+      required: true
+    },
+    configuration: {
+      type: Object,
+      required: true
+    },
+    offlineImage: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    }
+  },
+  computed: {
+    sliderOptions () {
+      return {
+        startAt: this.currentIndex,
+        type: 'slider',
+        autoplay: false,
+        rewind: false,
+        gap: 0
+      };
+    },
+    variantImage () {
+      let variantImage = this.gallery.find(
+        imageObject =>
+          isEqual(imageObject.id, this.option) ||
+          (imageObject.id && imageObject.id.color === this.option.color)
+      );
+
+      if (!variantImage) {
+        variantImage = this.gallery[0];
+      }
+
+      if (!this.isOnline) {
+        variantImage = this.offlineImage;
+      }
+
+      return variantImage;
+    },
+    additionalImage () {
+      const withoutVariantImage = this.gallery.filter(
+        imageObject => !isEqual(this.variantImage.id, imageObject.id)
+      );
+
+      if (!this.isOnline) {
+        return null;
+      }
+
+      return withoutVariantImage[0];
+    },
+    option () {
+      return reduce(
+        map(this.configuration, 'attribute_code'),
+        (result, attribute) => {
+          result[attribute] = this.configuration[attribute].id;
+          return result;
+        },
+        {}
+      );
+    },
+    isOnline () {
+      return onlineHelper.isOnline;
+    },
+    currentIndex () {
+      const index = this.gallery.findIndex(imageObject =>
+        isEqual(imageObject.id, this.variantImage.id)
+      );
+
+      return index === -1 ? 0 : index;
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+.m-product-gallery {
+  flex: 1;
+  &__mobile {
+    $height-other: 240px;
+    $height-iOS: 265px;
+
+    height: calc(100vh - #{$height-other});
+    @supports (-webkit-overflow-scrolling: touch) {
+      height: calc(100vh - #{$height-iOS});
+    }
+    ::v-deep .glide {
+      &,
+      * {
+        height: 100%;
+      }
+      &__slide {
+        position: relative;
+        overflow: hidden;
+      }
+      img {
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        min-width: calc((375 / 490) * (100vh - #{$height-other}));
+        @supports (-webkit-overflow-scrolling: touch) {
+          min-width: calc((375 / 490) * (100vh - #{$height-iOS}));
+        }
+      }
+    }
+    ::v-deep .sf-gallery__stage {
+      width: 100%;
+    }
+  }
+}
+</style>

--- a/components/molecules/m-product-options.vue
+++ b/components/molecules/m-product-options.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="m-product-options">
+    <SfSelect
+      v-model="size"
+      label="Size"
+      class="sf-select--bordered m-product-options__attribute"
+    >
+      <SfSelectOption
+        v-for="sizeOption in sizes"
+        :key="sizeOption.value"
+        :value="sizeOption.value"
+      >
+        <SfProductOption :label="sizeOption.label" />
+      </SfSelectOption>
+    </SfSelect>
+    <SfSelect
+      v-model="color"
+      label="Color"
+      class="sf-select--bordered m-product-options__attribute"
+    >
+      <SfSelectOption
+        v-for="colorOption in colors"
+        :key="colorOption.value"
+        :value="colorOption.value"
+      >
+        <SfProductOption
+          :label="colorOption.label"
+          :color="colorOption.color"
+        />
+      </SfSelectOption>
+    </SfSelect>
+  </div>
+</template>
+<script>
+import { SfSelect, SfProductOption } from '@storefront-ui/vue';
+export default {
+  name: 'MProductOptions',
+  components: {
+    SfSelect,
+    SfProductOption
+  },
+  data () {
+    return {
+      size: '',
+      sizes: [
+        { label: 'XXS', value: 'xxs' },
+        { label: 'XS', value: 'xs' },
+        { label: 'S', value: 's' },
+        { label: 'M', value: 'm' },
+        { label: 'L', value: 'l' },
+        { label: 'XL', value: 'xl' },
+        { label: 'XXL', value: 'xxl' }
+      ],
+      color: '',
+      colors: [
+        { label: 'Red', value: 'red', color: '#990611' },
+        { label: 'Black', value: 'black', color: '#000000' },
+        { label: 'Yellow', value: 'yellow', color: '#DCA742' },
+        { label: 'Blue', value: 'blue', color: '#004F97' },
+        { label: 'Navy', value: 'navy', color: '#656466' },
+        { label: 'White', value: 'white', color: '#FFFFFF' }
+      ]
+    };
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+.m-product-options {
+  border-bottom: 1px solid #f1f2f3;
+  padding-bottom: 10px;
+  @include for-desktop {
+    border: 0;
+    padding-bottom: 0;
+  }
+  &__attribute {
+    margin-bottom: $spacer-big;
+  }
+}
+</style>

--- a/components/molecules/m-product-short-info.vue
+++ b/components/molecules/m-product-short-info.vue
@@ -8,11 +8,11 @@
           class="sf-heading--no-underline sf-heading--left m-product-short-info__heading"
         />
         <div class="m-product-short-info__sub">
-          <AProductPrice
+          <!-- <AProductPrice
             class="sf-price--big m-product-short-info__sub-price"
             :product="product"
             :custom-options="customOptions"
-          />
+          /> -->
           <AProductRating
             :score="productRating.score"
             :max="productRating.max"
@@ -29,13 +29,13 @@
 <script>
 import { SfHeading } from '@storefront-ui/vue';
 import AProductRating from 'theme/components/atoms/a-product-rating';
-import AProductPrice from 'theme/components/atoms/a-product-price';
+// import AProductPrice from 'theme/components/atoms/a-product-price';
 export default {
   name: 'MProductShortInfo',
   components: {
     SfHeading,
-    AProductRating,
-    AProductPrice
+    AProductRating
+    // AProductPrice
   },
   props: {
     product: {

--- a/components/molecules/m-product-short-info.vue
+++ b/components/molecules/m-product-short-info.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="m-product-short-info">
+    <div class="m-product-short-info__mobile-top">
+      <div>
+        <SfHeading
+          :title="product.name | htmlDecode"
+          :level="1"
+          class="sf-heading--no-underline sf-heading--left m-product-short-info__heading"
+        />
+        <div class="m-product-short-info__sub">
+          <AProductPrice
+            class="sf-price--big m-product-short-info__sub-price"
+            :product="product"
+          />
+          <AProductRating
+            :score="productRating.score"
+            :max="productRating.max"
+            :review="productRating.review"
+          />
+        </div>
+      </div>
+    </div>
+    <div class="m-product-short-info__description desktop-only">
+      {{ $t("SKU: {sku}", { sku: product.sku }) }}
+    </div>
+  </div>
+</template>
+<script>
+import { SfHeading } from '@storefront-ui/vue';
+import AProductRating from 'theme/components/atoms/a-product-rating';
+import AProductPrice from 'theme/components/atoms/a-product-price';
+export default {
+  name: 'MProductShortInfo',
+  components: {
+    SfHeading,
+    AProductRating,
+    AProductPrice
+  },
+  props: {
+    product: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  computed: {
+    productRating () {
+      return {
+        score: 1,
+        max: 5,
+        review: 1
+      }
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+
+.m-product-short-info {
+  &__description {
+    margin: $spacer-extra-big 0 ($spacer-big * 3) 0;
+    font-family: $body-font-family-secondary;
+    font-size: $font-size-regular-mobile;
+    line-height: 1.6;
+    @include for-desktop {
+      font-size: $font-size-regular-desktop;
+    }
+  }
+  &__heading {
+    margin-top: $spacer-big;
+    ::v-deep .sf-heading__title {
+      font-size: $font-size-big-mobile;
+      font-weight: $body-font-weight-primary;
+      @include for-desktop {
+        font-size: $h1-font-size-desktop;
+        font-weight: $body-font-weight-secondary;
+      }
+    }
+    @include for-desktop {
+      margin-top: 0;
+    }
+  }
+  &__mobile-top {
+    display: flex;
+    align-items: center;
+    @include for-desktop {
+      display: block;
+    }
+  }
+  &__sub {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  &__sub-price {
+    flex-basis: 100%;
+    margin-top: $spacer-big / 4;
+    @include for-desktop {
+      flex-basis: auto;
+      margin-top: $spacer-big / 2;
+    }
+  }
+}
+</style>

--- a/components/molecules/m-product-short-info.vue
+++ b/components/molecules/m-product-short-info.vue
@@ -11,6 +11,7 @@
           <AProductPrice
             class="sf-price--big m-product-short-info__sub-price"
             :product="product"
+            :custom-options="customOptions"
           />
           <AProductRating
             :score="productRating.score"
@@ -38,6 +39,10 @@ export default {
   },
   props: {
     product: {
+      type: Object,
+      default: () => ({})
+    },
+    customOptions: {
       type: Object,
       default: () => ({})
     }

--- a/components/organisms/o-product-details.vue
+++ b/components/organisms/o-product-details.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="o-product-details">
+    <MProductGallery
+      :offline-image="offlineImage"
+      :gallery="gallery"
+      :configuration="productConfiguration"
+    />
+    <div class="o-product-details__description">
+      <SfSticky>
+        <MProductShortInfo :product="product" />
+        <ATextAction
+          class="o-product-details__text-action"
+          text="Size guide"
+          @click="openSizeGuide"
+        />
+        <MProductOptions />
+        <div class="o-product-details__section">
+          <SfAlert
+            message="Low in stock"
+            type="warning"
+            class="o-product-details__alert"
+          />
+          <MProductCallToAction />
+        </div>
+        <MProductAdditionalInfo />
+      </SfSticky>
+    </div>
+  </div>
+</template>
+<script>
+import config from 'config';
+import { mapGetters } from 'vuex';
+import { SfAlert, SfSticky } from '@storefront-ui/vue';
+import ATextAction from 'theme/components/atoms/a-text-action';
+import MProductGallery from 'theme/components/molecules/m-product-gallery';
+import MProductShortInfo from 'theme/components/molecules/m-product-short-info';
+import MProductOptions from 'theme/components/molecules/m-product-options';
+import MProductCallToAction from 'theme/components/molecules/m-product-call-to-action';
+import MProductAdditionalInfo from 'theme/components/molecules/m-product-additional-info';
+
+export default {
+  components: {
+    SfAlert,
+    SfSticky,
+    ATextAction,
+    MProductGallery,
+    MProductShortInfo,
+    MProductOptions,
+    MProductCallToAction,
+    MProductAdditionalInfo
+  },
+  props: {
+    product: {
+      type: Object,
+      default: () => ({})
+    },
+    productGallery: {
+      type: Array,
+      default: () => []
+    },
+    productConfiguration: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  computed: {
+    offlineImage () {
+      const width = config.products.thumbnails.width;
+      const height = config.products.thumbnails.height;
+      return {
+        small: {
+          url: this.getThumbnail(this.product.image, width, height),
+          alt: this.product.name
+        },
+        normal: {
+          url: this.getThumbnail(this.product.image, width, height),
+          alt: this.product.name
+        },
+        big: {
+          url: this.getThumbnail(this.product.image, width, height),
+          alt: this.product.name
+        }
+      };
+    },
+    gallery () {
+      return this.productGallery.map(imageObject => ({
+        ...imageObject,
+        small: {
+          url: imageObject.loading,
+          alt: this.product.name
+        },
+        normal: {
+          url: imageObject.src,
+          alt: this.product.name
+        },
+        big: {
+          url: imageObject.src,
+          alt: this.product.name
+        }
+      }));
+    }
+  },
+  methods: {
+    openSizeGuide () {
+      this.$bus.$emit('modal-show', 'modal-sizeguide');
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/vue/styles";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+
+.o-product-details {
+  @include for-desktop {
+    display: flex;
+  }
+  &__description {
+    flex: 1;
+    padding: 0 $spacer-big;
+    @include for-desktop {
+      margin-left: $spacer-big * 5;
+    }
+  }
+  &__text-action {
+    @include for-desktop {
+      justify-content: flex-end;
+    }
+  }
+  &__alert {
+    margin-top: 1.5rem;
+  }
+  &__section {
+    border-bottom: 1px solid #f1f2f3;
+    padding-bottom: 10px;
+    @include for-desktop {
+      border: 0;
+      padding-bottom: 0;
+    }
+  }
+}
+</style>

--- a/components/organisms/o-product-details.vue
+++ b/components/organisms/o-product-details.vue
@@ -7,7 +7,7 @@
     />
     <div class="o-product-details__description">
       <SfSticky>
-        <MProductShortInfo :product="product" />
+        <MProductShortInfo :product="product" :custom-options="productCustomOptions" />
         <ATextAction
           class="o-product-details__text-action"
           text="Size guide"
@@ -59,6 +59,10 @@ export default {
       default: () => []
     },
     productConfiguration: {
+      type: Object,
+      default: () => ({})
+    },
+    productCustomOptions: {
       type: Object,
       default: () => ({})
     }

--- a/pages/Product.vue
+++ b/pages/Product.vue
@@ -9,6 +9,7 @@
       :product="getCurrentProduct"
       :product-gallery="getProductGallery"
       :product-configuration="getCurrentProductConfiguration"
+      :product-custom-options="getCurrentCustomOptions"
     />
     <lazy-hydrate when-idle>
       <SfSection
@@ -85,7 +86,8 @@ export default {
       getProductGallery: 'product/getProductGallery',
       getCurrentProductConfiguration: 'product/getCurrentProductConfiguration',
       getOriginalProduct: 'product/getOriginalProduct',
-      attributesByCode: 'attribute/attributeListByCode'
+      attributesByCode: 'attribute/attributeListByCode',
+      getCurrentCustomOptions: 'product/getCurrentCustomOptions'
     }),
     getOptionLabel () {
       return option => {

--- a/resource/i18n/en-US.csv
+++ b/resource/i18n/en-US.csv
@@ -317,3 +317,4 @@
 "I want to create an account","I want to create an account"
 "Create an account","Create an account"
 "login in to your account","login in to your account"
+"Read all {review} review","Read all {review} review"


### PR DESCRIPTION
Closes: #48 
Related: #49, #50 

Description:
I moved 1:1 view from sfui with dummy data and split it to our component structure.
Completed components:
- a-product-price => this require vsf 1.11.1 which is not released now, but for sure will be before this theme release. You can uncomment it in m-product-short-info
- a-product-rating
- a-text-action
- m-product-gallery
- m-product-short-info

Rest of components requires to pass right data. I will finish this in issue 49 and 50

I will remove components from `core` and `theme` after all product page is finished.