### PR TITLE
Disable unused modules from vsf

### DIFF
--- a/config/modules.ts
+++ b/config/modules.ts
@@ -1,0 +1,44 @@
+import { VueStorefrontModule } from '@vue-storefront/core/lib/module'
+import { CatalogModule } from '@vue-storefront/core/modules/catalog'
+import { CatalogNextModule } from '@vue-storefront/core/modules/catalog-next'
+import { CartModule } from '@vue-storefront/core/modules/cart'
+import { CheckoutModule } from '@vue-storefront/core/modules/checkout'
+import { CompareModule } from '@vue-storefront/core/modules/compare'
+import { WishlistModule } from '@vue-storefront/core/modules/wishlist'
+import { NotificationModule } from '@vue-storefront/core/modules/notification'
+import { UrlModule } from '@vue-storefront/core/modules/url'
+import { BreadcrumbsModule } from '@vue-storefront/core/modules/breadcrumbs'
+import { UserModule } from '@vue-storefront/core/modules/user'
+import { CmsModule } from '@vue-storefront/core/modules/cms'
+import { GoogleTagManagerModule } from 'src/modules/google-tag-manager'
+// import { AmpRendererModule } from 'src/modules/amp-renderer'
+import { PaymentBackendMethodsModule } from 'src/modules/payment-backend-methods'
+import { PaymentCashOnDeliveryModule } from 'src/modules/payment-cash-on-delivery'
+import { NewsletterModule } from '@vue-storefront/core/modules/newsletter'
+
+import { registerModule } from '@vue-storefront/core/lib/modules'
+
+// TODO:distributed across proper pages BEFORE 1.11
+export function registerClientModules () {
+  registerModule(UrlModule)
+  registerModule(CatalogModule)
+  registerModule(CheckoutModule) // To Checkout
+  registerModule(CartModule)
+  registerModule(PaymentBackendMethodsModule)
+  registerModule(PaymentCashOnDeliveryModule)
+  registerModule(WishlistModule) // Trigger on wishlist icon click
+  registerModule(NotificationModule)
+  registerModule(UserModule) // Trigger on user icon click
+  registerModule(CatalogNextModule)
+  registerModule(CompareModule)
+  registerModule(BreadcrumbsModule)
+  registerModule(GoogleTagManagerModule)
+  // registerModule(AmpRendererModule)
+  registerModule(CmsModule)
+  registerModule(NewsletterModule)
+}
+
+// Deprecated API, will be removed in 2.0
+export const registerModules: VueStorefrontModule[] = [
+  // Example
+]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,16 @@
 // You can extend default webpack build here.
 // Read more in docs: https://github.com/DivanteLtd/vue-storefront/blob/master/docs/guide/core-themes/webpack.md
+const merge = require('webpack-merge');
+const themeRoot = require('@vue-storefront/core/build/theme-path');
+
 module.exports = function (config) {
-  return config;
+  return merge({
+    default: {
+      resolve: {
+        alias: {
+          'src/modules/client': `${themeRoot}/config/modules`
+        }
+      }
+    }
+  }, config);
 };


### PR DESCRIPTION
Closes #72 

Now it is possible to disable modules in theme: just comment out unused module in `<path to capybara theme>/config/modules.ts`. By default `AmpRendererModule` has been disabled.