### PR TITLE
Fix `postcss-flexbugs-fixes` plugin integration with `storefront-ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
-    "husky": "^3.1.0"
+    "husky": "^3.1.0",
+    "postcss-filter-stream": "^0.0.6"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,52 @@
 // Read more in docs: https://github.com/DivanteLtd/vue-storefront/blob/master/docs/guide/core-themes/webpack.md
 const merge = require('webpack-merge');
 const themeRoot = require('@vue-storefront/core/build/theme-path');
+const filterStream = require('postcss-filter-stream');
+
+/**
+ * Searches for given plugin name and wraps it with 'postcss-filter-stream' plugin to configure
+ * paths that must be skipped for requested plugin.
+ *
+ * @param {object} loader
+ * @param {string} pluginName
+ * @param {string} filter
+ */
+function addFilterStreamForPostCSSPlugin (loader, pluginName, filter) {
+  const plugins = loader.options.plugins instanceof Function
+    ? loader.options.plugins()
+    : loader.options.plugins;
+  const index = plugins.findIndex(plugin => plugin().postcssPlugin === pluginName);
+
+  if (index !== -1) {
+    plugins[index] = filterStream(filter, plugins[index]());
+    loader.options.plugins = loader.options.plugins instanceof Function
+      ? () => plugins
+      : plugins;
+  }
+}
+
+/**
+ * Traverses webpack's module rules to find all PostCSS loaders. For each PostCSS loader
+ * the 'postcss-flexbugs-fixes' plugin has to be found and it has to be configured to skip
+ * @storefront-ui library from being processed.
+ *
+ * @param {object} rules
+ */
+function fixPostCSSPlugins (rules) {
+  const processedLoaders = [];
+
+  rules.forEach(rule => {
+    const loader = rule.use ? rule.use.find(item => item.loader === 'postcss-loader') : null;
+
+    if (loader && !processedLoaders.includes(loader)) {
+      addFilterStreamForPostCSSPlugin(loader, 'postcss-flexbugs-fixes', '**/@storefront-ui/**');
+      processedLoaders.push(loader);
+    }
+  });
+}
 
 module.exports = function (config) {
-  return merge({
+  const mergedConfig = merge({
     default: {
       resolve: {
         alias: {
@@ -13,4 +56,8 @@ module.exports = function (config) {
       }
     }
   }, config);
+
+  fixPostCSSPlugins(mergedConfig.default.module.rules);
+
+  return mergedConfig;
 };


### PR DESCRIPTION
Closes #71 

The `SfTable` component in `storefront-ui` uses `calc()` with CSS variable [here](https://github.com/DivanteLtd/storefront-ui/blob/3584689ff3890d748460cededbebc9686e42c538/packages/shared/styles/components/SfTable.scss#L40)
```
flex: 0 0 calc(100% / var(--mobile-column));
```
According to [this note](https://github.com/philipwalton/flexbugs#flexbug-8) 
> `flex-basis` doesn't support `calc()`

so this line is parsed by `postcss-flexbugs-fixes` which tries to re-write it as separate `flex-basis`, `flex-shrink` and `flex-grow` declarations. Unfortunately [this regex](https://github.com/luisrudge/postcss-flexbugs-fixes/blob/c51f4e749722982498bef27c36dbee1ebd1e0a4d/bugs/bug81a.js#L4) does not support CSS variables inside `calc()` in `flex` declaration and due to that this rule is re-written with syntax error - missing one (last) parenthesis.

Conclusion: because `vue-storefront` uses `postcss-flexbugs-fixes` and this plugin is not compatible with recent changes in `storefront-ui`, in this PR `postcss-flexbugs-fixes` was configured to skip parsing whole `storefront-ui` library.