### PR TITLE
Fixed missing modalData prop

### DIFF
--- a/components/molecules/modals/m-modal-account-benefits.vue
+++ b/components/molecules/modals/m-modal-account-benefits.vue
@@ -67,6 +67,11 @@ export default {
     isVisible: {
       type: Boolean,
       default: false
+    },
+    modalData: {
+      type: Object,
+      default: () => ({}),
+      required: true
     }
   },
   methods: {

--- a/components/molecules/modals/m-modal-terms-and-conditions.vue
+++ b/components/molecules/modals/m-modal-terms-and-conditions.vue
@@ -70,6 +70,11 @@ export default {
     isVisible: {
       type: Boolean,
       default: false
+    },
+    modalData: {
+      type: Object,
+      default: () => ({}),
+      required: true
     }
   },
   methods: {


### PR DESCRIPTION
`modalData` prop was missing in two modals, which was the reason that they were not possible to close: `TypeError: "this.modalData is undefined"`