### PR TITLE
Hide pagination if there is only one page

### DIFF
--- a/components/molecules/m-review-list.vue
+++ b/components/molecules/m-review-list.vue
@@ -13,6 +13,7 @@
       :hide-full-text="$t('Read less')"
     />
     <SfPagination
+      v-if="total > 1"
       :current="currentPage"
       :visible="visible"
       :total="total"

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -107,6 +107,7 @@
             </div>
           </lazy-hydrate>
           <SfPagination
+            v-if="totalPages > 1"
             class="products__pagination desktop-only"
             :current="currentPage"
             :total="totalPages"


### PR DESCRIPTION
Closes #123 

These changes hide pagination element if there is only one page to show.