### PR TITLE
Do not show filter count if it is 0

### DIFF
--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -342,7 +342,7 @@ export default {
         .reduce((result, [filterType, filters]) => {
           result[`${filterType}_filter`] = filters.map(filter => ({
             ...filter,
-            count: this.getFilterCount(filter),
+            count: this.getFilterCount(filter) || '',
             color:
               filterType === 'color'
                 ? (config.products.colorMappings &&
@@ -562,8 +562,7 @@ export default {
             );
 
           return bucket ? result + bucket.doc_count : result;
-        }, 0)
-        .toString();
+        }, 0);
     }
   },
   metaInfo () {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #122 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Empty string is used if filter count is 0 so now after opening filter sidebar first time it will not show meaningless zeros anymore.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![filter](https://user-images.githubusercontent.com/56868128/73930998-d06a0900-48d7-11ea-91ff-9ee340e63ea1.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)