### PR TITLE
Fixed src path for social icons

### DIFF
--- a/components/organisms/o-footer.vue
+++ b/components/organisms/o-footer.vue
@@ -45,7 +45,7 @@
           <img
             v-for="item in social"
             :key="item"
-            :src="'assets/icons/' + item + '.svg'"
+            :src="'/assets/icons/' + item + '.svg'"
             class="social-icon__img"
           >
         </div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Closes #132

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
It fixes `src` path for social icons in footer.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Now it works fine on any page:

![footer](https://user-images.githubusercontent.com/56868128/73942431-55145180-48ef-11ea-87b9-bba1b1cf10f4.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)