### PR TITLE
Simplify webpack.config.js after VSF v1.11.1

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,23 +47,14 @@ function fixPostCSSPlugins (rules) {
 }
 
 module.exports = function (config) {
-  /**
-   * This webpack config depends on the build type: for development build it is wrapped inside 'default' key
-   * but for production build this 'default' key does not exist. This misconfiguration should be fixed in
-   * Vue Storefront v1.11.1 and then 'hasDefaultKey' will never be true, so all these lines could be then
-   * simplified/removed.
-   */
-
-  const hasDefaultKey = config.default !== undefined; // TODO: remove after Vue Storefront v1.11.1 release
-
   const mergedConfig = merge(
+    // alias for 'src/modules/client' has to be the first one, because it has to be
+    // handled earlier than already existing aliases in VSF (like general 'src' path)
     { resolve: { alias: { 'src/modules/client': `${themeRoot}/config/modules` } } },
-    hasDefaultKey ? config.default : config // TODO: simplify after Vue Storefront v1.11.1 release
+    config
   );
 
   fixPostCSSPlugins(mergedConfig.module.rules);
 
-  return hasDefaultKey // TODO: simplify after Vue Storefront v1.11.1 release
-    ? { default: mergedConfig }
-    : mergedConfig;
+  return mergedConfig;
 };


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #138 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
After Vue Storefront v1.11.1 it is now possible to simplify `webpack.config.js` because it will never be called with configuration object wrapped inside `default` key for development build 🎉 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)