### PR TITLE
Fix and unify price calculation methods

### DIFF
--- a/components/atoms/a-product-price.vue
+++ b/components/atoms/a-product-price.vue
@@ -1,15 +1,12 @@
 <template>
   <SfPrice
-    :regular="renderPrice.regular"
-    :special="renderPrice.special"
+    :regular="price.regular"
+    :special="price.special"
   />
 </template>
 <script>
-import { price } from '@vue-storefront/core/filters';
-import { getCustomOptionValues, getCustomOptionPriceDelta } from '@vue-storefront/core/modules/catalog/helpers/customOption'
-import { getBundleOptionsValues, getBundleOptionPrice } from '@vue-storefront/core/modules/catalog/helpers/bundleOptions'
-import get from 'lodash-es/get'
 import { SfPrice } from '@storefront-ui/vue';
+import { getProductPrice } from 'theme/helpers'
 export default {
   name: 'AProductPrice',
   components: {
@@ -26,61 +23,8 @@ export default {
     }
   },
   computed: {
-    bundleOptionsPrice () {
-      const allBundleOptions = this.product.bundle_options || []
-      const selectedBundleOptions = Object.values(get(this.product, 'product_option.extension_attributes.bundle_options', {}))
-      const price = getBundleOptionPrice(
-        getBundleOptionsValues(selectedBundleOptions, allBundleOptions)
-      )
-      return price
-    },
-    customOptionsPriceDelta () {
-      const priceDelta = getCustomOptionPriceDelta(
-        getCustomOptionValues(Object.values(this.customOptions), this.product.custom_options),
-        this.product
-      )
-
-      return priceDelta
-    },
     price () {
-      const special = (this.productPrices.priceInclTax + this.customOptionsPriceDelta.priceInclTax) * this.product.qty
-      const original = (this.productPrices.originalPriceInclTax + this.customOptionsPriceDelta.priceInclTax) * this.product.qty
-      const defaultPrice = this.product.qty > 0
-        ? (this.productPrices.priceInclTax + this.customOptionsPriceDelta.priceInclTax) * this.product.qty
-        : this.productPrices.priceInclTax
-
-      if (this.bundleOptionsPrice.priceInclTax > 0) {
-        return {
-          special,
-          original,
-          default: this.bundleOptionsPrice.priceInclTax
-        }
-      }
-
-      return {
-        special,
-        original,
-        default: defaultPrice
-      }
-    },
-    isSpecialPrice () {
-      return this.productPrices.specialPrice && this.productPrices.priceInclTax && this.productPrices.originalPriceInclTax
-    },
-    renderPrice () {
-      return {
-        regular: this.isSpecialPrice ? price(this.price.original) : price(this.price.default),
-        special: this.isSpecialPrice ? price(this.price.special) : ''
-      }
-    },
-    productPrices () {
-      const priceInclTax = this.product.price_incl_tax || this.product.priceInclTax || 0
-      const originalPriceInclTax = this.product.original_price_incl_tax || this.product.originalPriceInclTax || 0
-      const specialPrice = this.product.special_price || this.product.specialPrice || 0
-      return {
-        priceInclTax,
-        originalPriceInclTax,
-        specialPrice
-      }
+      return getProductPrice(this.product, this.customOptions)
     }
   }
 }

--- a/components/molecules/m-product-carousel.vue
+++ b/components/molecules/m-product-carousel.vue
@@ -17,11 +17,12 @@
 </template>
 <script>
 import { SfProductCard, SfCarousel } from '@storefront-ui/vue';
-import { price, htmlDecode } from '@vue-storefront/core/filters';
+import { htmlDecode } from '@vue-storefront/core/filters';
 import config from 'config';
 import { currentStoreView } from '@vue-storefront/core/lib/multistore';
 import { formatProductLink } from '@vue-storefront/core/modules/url/helpers';
 import { productThumbnailPath } from '@vue-storefront/core/helpers';
+import { getProductPrice } from 'theme/helpers';
 export default {
   name: 'MProductCarousel',
   components: {
@@ -45,10 +46,7 @@ export default {
             config.products.thumbnails.height
           ),
           link: formatProductLink(product, currentStoreView().storeCode),
-          price: {
-            regular: price(parseFloat(product.priceInclTax)),
-            special: price(parseFloat(product.specialPriceInclTax))
-          },
+          price: getProductPrice(product),
           rating: {
             max: 5,
             score: 5

--- a/components/organisms/o-microcart.vue
+++ b/components/organisms/o-microcart.vue
@@ -11,8 +11,8 @@
             :key="product.id"
             :image="getThumbnailForProductExtend(product)"
             :title="product.name"
-            :regular-price="getProductPrice(product.totals).regular"
-            :special-price="getProductPrice(product.totals).special"
+            :regular-price="getProductPrice(product).regular"
+            :special-price="getProductPrice(product).special"
             :stock="10"
             class="collected-product"
             @click:remove="removeHandler(product)"
@@ -77,8 +77,9 @@
 <script>
 import { mapGetters } from 'vuex';
 import { localizedRoute } from '@vue-storefront/core/lib/multistore';
+import { onlineHelper } from '@vue-storefront/core/helpers';
 import { getThumbnailForProduct } from '@vue-storefront/core/modules/cart/helpers';
-import { getProductPrice } from 'theme/helpers';
+import { getProductPrice, getProductPriceFromTotals } from 'theme/helpers';
 import VueOfflineMixin from 'vue-offline/mixin';
 import onEscapePress from '@vue-storefront/core/mixins/onEscapePress';
 
@@ -136,7 +137,9 @@ export default {
       return getThumbnailForProduct(product);
     },
     getProductPrice (product) {
-      return getProductPrice(product);
+      return onlineHelper.isOnline && product.totals && product.totals.options
+        ? getProductPriceFromTotals(product)
+        : getProductPrice(product);
     },
     removeHandler (product) {
       this.$store.dispatch('cart/removeItem', { product: product });

--- a/components/organisms/o-microcart.vue
+++ b/components/organisms/o-microcart.vue
@@ -14,6 +14,7 @@
             :regular-price="getProductPrice(product).regular"
             :special-price="getProductPrice(product).special"
             :stock="10"
+            :qty="product.qty"
             class="collected-product"
             @click:remove="removeHandler(product)"
             @input="changeQuantity(product, $event)"
@@ -153,7 +154,21 @@ export default {
         product: product,
         qty: newQuantity
       });
+    },
+    onQuantityChange () {
+      // Unfortunately $forceUpdate() is needed here because `totals` key in cart items
+      // is added but not in a reactive way, so Vue is not able to detect this change and
+      // re-render our view.
+      // The callback for 'cart-after-itemchanged' event can be removed when the following PR
+      // will be merged in VSF: https://github.com/DivanteLtd/vue-storefront/pull/4079/
+      this.$forceUpdate();
     }
+  },
+  beforeMount () {
+    this.$bus.$on('cart-after-itemchanged', this.onQuantityChange);
+  },
+  beforeDestroy () {
+    this.$bus.$off('cart-after-itemchanged', this.onQuantityChange);
   }
 };
 </script>

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,6 +1,8 @@
 import config from 'config'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
+export * from './price'
+
 export function getPathForStaticPage (path: string) {
   const { storeCode } = currentStoreView()
   const isStoreCodeEquals = storeCode === config.defaultStoreCode

--- a/helpers/price.ts
+++ b/helpers/price.ts
@@ -23,10 +23,17 @@ function calculateCustomOptionsPriceDelta (product, customOptions) {
 }
 
 function formatPrice (value) {
-  return value ? price(value) : '';
+  return value ? price(value) : ''
 }
 
 export function getProductPrice (product, customOptions = {}) {
+  if (!product) {
+    return {
+      regular: '',
+      special: ''
+    }
+  }
+
   const priceInclTax = product.price_incl_tax || product.priceInclTax || 0
   const originalPriceInclTax = product.original_price_incl_tax || product.originalPriceInclTax || 0
   const specialPrice = product.special_price || product.specialPrice || 0
@@ -40,6 +47,25 @@ export function getProductPrice (product, customOptions = {}) {
 
   return {
     regular: isSpecialPrice ? formatPrice(original) : formatPrice(regular),
+    special: isSpecialPrice ? formatPrice(special) : ''
+  }
+}
+
+export function getProductPriceFromTotals (product) {
+  if (!product.totals || !product.totals.options) {
+    return {
+      regular: '',
+      special: ''
+    }
+  }
+
+  const isSpecialPrice = product.totals.discount_amount > 0
+
+  const special = product.totals.row_total_incl_tax - product.totals.discount_amount
+  const regular = product.totals.row_total_incl_tax
+
+  return {
+    regular: formatPrice(regular),
     special: isSpecialPrice ? formatPrice(special) : ''
   }
 }

--- a/helpers/price.ts
+++ b/helpers/price.ts
@@ -1,0 +1,45 @@
+import { price } from '@vue-storefront/core/filters';
+import { getCustomOptionValues, getCustomOptionPriceDelta } from '@vue-storefront/core/modules/catalog/helpers/customOption'
+import { getBundleOptionsValues, getBundleOptionPrice } from '@vue-storefront/core/modules/catalog/helpers/bundleOptions'
+import get from 'lodash-es/get'
+
+function calculateBundleOptionsPrice (product) {
+  const allBundleOptions = product.bundle_options || []
+  const selectedBundleOptions = Object.values(get(product, 'product_option.extension_attributes.bundle_options', {}))
+  const price = getBundleOptionPrice(
+    getBundleOptionsValues(selectedBundleOptions, allBundleOptions)
+  )
+
+  return price.priceInclTax
+}
+
+function calculateCustomOptionsPriceDelta (product, customOptions) {
+  const priceDelta = getCustomOptionPriceDelta(
+    getCustomOptionValues(Object.values(customOptions), product.custom_options),
+    product
+  )
+
+  return priceDelta.priceInclTax
+}
+
+function formatPrice (value) {
+  return value ? price(value) : '';
+}
+
+export function getProductPrice (product, customOptions = {}) {
+  const priceInclTax = product.price_incl_tax || product.priceInclTax || 0
+  const originalPriceInclTax = product.original_price_incl_tax || product.originalPriceInclTax || 0
+  const specialPrice = product.special_price || product.specialPrice || 0
+
+  const isSpecialPrice = specialPrice && priceInclTax && originalPriceInclTax
+  const priceDelta = calculateCustomOptionsPriceDelta(product, customOptions)
+
+  const special = (priceInclTax + priceDelta) * product.qty || priceInclTax
+  const original = (originalPriceInclTax + priceDelta) * product.qty || originalPriceInclTax
+  const regular = calculateBundleOptionsPrice(product) || (priceInclTax + priceDelta) * product.qty || priceInclTax
+
+  return {
+    regular: isSpecialPrice ? formatPrice(original) : formatPrice(regular),
+    special: isSpecialPrice ? formatPrice(special) : ''
+  }
+}

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -167,7 +167,7 @@ import {
 } from '@vue-storefront/core/helpers';
 import i18n from '@vue-storefront/i18n';
 import onBottomScroll from '@vue-storefront/core/mixins/onBottomScroll';
-import { price, htmlDecode } from '@vue-storefront/core/filters';
+import { htmlDecode } from '@vue-storefront/core/filters';
 import { quickSearchByQuery } from '@vue-storefront/core/lib/search';
 import { getSearchOptionsFromRouteParams } from '@vue-storefront/core/modules/catalog-next/helpers/categoryHelpers';
 import { catalogHooksExecutors } from '@vue-storefront/core/modules/catalog-next/hooks';
@@ -179,6 +179,7 @@ import {
   formatCategoryLink,
   formatProductLink
 } from '@vue-storefront/core/modules/url/helpers';
+import { getProductPrice } from 'theme/helpers';
 import {
   localizedRoute,
   currentStoreView
@@ -473,14 +474,14 @@ export default {
               id: category.id,
               name: category.name,
               link: formatCategoryLink(category),
-              count: String(category.product_count),
+              count: category.product_count,
               position: category.position,
               items: this.prepareCategories(subCategory.children_data, [
                 {
                   id: category.id,
                   name: i18n.t('View all'),
                   link: formatCategoryLink(category),
-                  count: String(category.product_count),
+                  count: category.product_count,
                   position: 0
                 }
               ])
@@ -499,10 +500,7 @@ export default {
           config.products.thumbnails.height
         ),
         link: formatProductLink(product, currentStoreView().storeCode),
-        price: {
-          regular: price(parseFloat(product.priceInclTax)),
-          special: price(parseFloat(product.specialPriceInclTax))
-        },
+        price: getProductPrice(product),
         rating: {
           max: 5,
           score: 5


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #142

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR unifies and fixes price calculation in all places.

Previous implementation was moved from `components\atoms\a-product-price.vue` to new `helpers\price.ts` and then it is used in all places where it is needed. It had to be moved to a helper module to be able to use it as a function - we are using components like `SfCollectedProduct` or `SfProductCard` which could not use previous `a-product-price.vue`, but they require providing prices (regular and special) as props.

If calculated price is 0 then it is not displayed.

This PR also fixes price calculation in microcart: now it is a sum of all product's prices including taxes - just like it is in default theme.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Now prices are calculated correctly:

![Home banner](https://user-images.githubusercontent.com/56868128/74238895-07289080-4cd7-11ea-979d-f2ae2b4a1114.png)

![Category page](https://user-images.githubusercontent.com/56868128/74238974-30492100-4cd7-11ea-9be1-596a98f1a6a3.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)