### PR TITLE
Fixed duplicated requests on Homepage in SSR

### DIFF
--- a/components/atoms/a-images-grid.vue
+++ b/components/atoms/a-images-grid.vue
@@ -3,7 +3,7 @@
     <div v-for="singleRow in row" :key="singleRow" class="a-images-grid__row">
       <div v-for="singleCol in col" :key="singleCol" class="a-images-grid__col">
         <SfImage
-          :src="typeof getImage(singleRow, singleCol).image === 'string' ? getImage(singleRow, singleCol).image : ''"
+          :src="getImage(singleRow, singleCol).image"
         />
       </div>
     </div>

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -23,8 +23,9 @@ export function createSmoothscroll (from = 0, to = 0, speed = 15) {
 }
 
 export function checkWebpSupport (bannersToTransform, isWebpSupported) {
-  return bannersToTransform.map(banner => {
-    if (isServer || isWebpSupported === null) return banner
-    return Object.assign({}, banner, { image: isWebpSupported ? banner.image.webp : banner.image.fallback })
-  })
+  return bannersToTransform.map(banner => Object.assign(
+    {},
+    banner,
+    { image: !isServer && isWebpSupported ? banner.image.webp : banner.image.fallback }
+  ))
 }

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -23,9 +23,10 @@ export function createSmoothscroll (from = 0, to = 0, speed = 15) {
 }
 
 export function checkWebpSupport (bannersToTransform, isWebpSupported) {
+  const theSmallestDummyImage = 'data:,'
   return bannersToTransform.map(banner => Object.assign(
     {},
     banner,
-    { image: !isServer && isWebpSupported ? banner.image.webp : banner.image.fallback }
+    { image: isServer ? theSmallestDummyImage : isWebpSupported ? banner.image.webp : banner.image.fallback }
   ))
 }

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -23,6 +23,13 @@ export function createSmoothscroll (from = 0, to = 0, speed = 15) {
 }
 
 export function checkWebpSupport (bannersToTransform, isWebpSupported) {
+  // In SSR it is not easily known whether webp image is supported by web browser or not.
+  // Empty string also cannot be used here, because empty string evaluates to url('')
+  // and it is resolved as the base URL (the same as our Homepage), so as a consequence
+  // Homepage was requested again.
+  // To fix that case, dummy empty data URI is provided just to prevent any unnecessary
+  // requests.
+  // --- see https://github.com/DivanteLtd/vsf-capybara/issues/168
   const theSmallestDummyImage = 'data:,'
   return bannersToTransform.map(banner => Object.assign(
     {},

--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -6,7 +6,7 @@
         :key="i"
         :title="hero.title"
         :subtitle="hero.subtitle"
-        :image="typeof hero.image === 'string' ? hero.image : ''"
+        :image="hero.image"
       />
     </SfHero>
 
@@ -18,7 +18,7 @@
             :title="banner.title"
             :description="banner.description"
             :button-text="banner.buttonText"
-            :image="typeof banner.image === 'string' ? banner.image : ''"
+            :image="banner.image"
             class="sf-banner--slim"
           />
         </router-link>
@@ -28,7 +28,7 @@
     <SfCallToAction
       title="Subscribe to Newsletters"
       description="Be aware of upcoming sales and events. Receive gifts and special offers!"
-      :image="typeof newsletterImage === 'string' ? newsletterImage : ''"
+      :image="newsletterImage"
       class="call-to-action-newsletter"
     >
       <template #button>

--- a/store/ui/index.ts
+++ b/store/ui/index.ts
@@ -18,7 +18,7 @@ export const uiStore = {
       depth: false,
       path: []
     },
-    isWebpSupported: null
+    isWebpSupported: true
   },
   mutations: {
     setCheckoutMode (state, action) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #168 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This fixes duplicated `GET '/'` on Homepage. It was caused because for SSR empty `:image` prop was provided and this empty string was used as `background-image: url('')` in `SfHeroItem` component. Empty image URL in `url('')` is a relative URL, which resolves to the base URL, in this case the same as our Homepage, so it was requested again with headers `Accept: image/webp,*/*` (in Firefox) or `Accept: image/webp,image/apng,image/*,*/*;q=0.8` (in Chrome) saying "we want an image this time".

So it was just needed to provide valid image URL to prevent double `GET '/'` requests.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)