### PR TITLE
Unify categories shown in header with these on Category page

### DIFF
--- a/components/organisms/o-header.vue
+++ b/components/organisms/o-header.vue
@@ -39,6 +39,7 @@ import AAccountIcon from 'theme/components/atoms/a-account-icon';
 import AMicrocartIcon from 'theme/components/atoms/a-microcart-icon';
 import { mapGetters } from 'vuex';
 import { formatCategoryLink } from '@vue-storefront/core/modules/url/helpers';
+import { getTopLevelCategories } from 'theme/helpers';
 import config from 'config'
 
 export default {
@@ -57,10 +58,7 @@ export default {
       return this.isLoggedIn ? 'account' : '';
     },
     categories () {
-      return this.getCategories.filter(
-        category => (category.level === (config.entities.category.categoriesDynamicPrefetchLevel >= 0 ? config.entities.category.categoriesDynamicPrefetchLevel : 2)) && // display only the root level (level =1 => Default Category), categoriesDynamicPrefetchLevel = 2 by default
-        (category.is_active && category.children_count > 0)
-      );
+      return getTopLevelCategories(this.getCategories);
     }
   },
   methods: {

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -37,3 +37,14 @@ export function checkWebpSupport (bannersToTransform, isWebpSupported) {
     { image: isServer ? theSmallestDummyImage : isWebpSupported ? banner.image.webp : banner.image.fallback }
   ))
 }
+
+export function getTopLevelCategories (categoryList) {
+  // Display only the root level (level = 1 => Default Category), categoriesDynamicPrefetchLevel = 2 by default
+  const categoryLevel = config.entities.category.categoriesDynamicPrefetchLevel >= 0
+    ? config.entities.category.categoriesDynamicPrefetchLevel
+    : 2
+
+  return categoryList.filter(
+    category => category.level === categoryLevel && category.is_active && category.children_count > 0
+  )
+}

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -179,6 +179,7 @@ import { htmlDecode } from '@vue-storefront/core/filters';
 import { quickSearchByQuery } from '@vue-storefront/core/lib/search';
 import { getSearchOptionsFromRouteParams } from '@vue-storefront/core/modules/catalog-next/helpers/categoryHelpers';
 import { catalogHooksExecutors } from '@vue-storefront/core/modules/catalog-next/hooks';
+import { getTopLevelCategories } from 'theme/helpers';
 import AIconFilter from 'theme/components/atoms/a-icon-filter';
 import AIconSort from 'theme/components/atoms/a-icon-sort';
 import AIconViewGrid from 'theme/components/atoms/a-icon-view-grid';
@@ -282,8 +283,7 @@ export default {
       getAvailableFilters: 'category-next/getAvailableFilters',
       getCurrentFilters: 'category-next/getCurrentFilters',
       getSystemFilterNames: 'category-next/getSystemFilterNames',
-      getCategories: 'category-next/getCategories',
-      categoryList: 'category/getCategories',
+      getCategories: 'category/getCategories',
       getBreadcrumbsRoutes: 'breadcrumbs/getBreadcrumbsRoutes',
       getBreadcrumbsCurrent: 'breadcrumbs/getBreadcrumbsCurrent'
     }),
@@ -309,7 +309,26 @@ export default {
         });
     },
     categories () {
-      return this.prepareCategories(this.getCategories[0].children_data);
+      return getTopLevelCategories(this.getCategories)
+        .map(category => {
+          const viewAllMenuItem = {
+            ...category,
+            name: i18n.t('View all'),
+            position: 0
+          };
+
+          return {
+            ...this.prepareCategoryMenuItem(category),
+            items: [this.prepareCategoryMenuItem(viewAllMenuItem)]
+              .concat(
+                category.children_data.map(childCategory => this.prepareCategoryMenuItem(
+                  this.getCategories.find(category => category.id === childCategory.id)
+                ))
+              )
+              .sort((a, b) => a.position - b.position)
+          };
+        })
+        .sort((a, b) => a.position - b.position);
     },
     products () {
       // lazy loading is disabled for desktop screen width (>= 1024px)
@@ -470,37 +489,16 @@ export default {
     initPagination () {
       this.currentPage = 1;
     },
-    prepareCategories (categories, firstItem = []) {
-      return categories
-        ? categories
-          .reduce((result, subCategory) => {
-            const category = this.categoryList.find(
-              c => c.id === subCategory.id
-            );
+    prepareCategoryMenuItem (category) {
+      if (!category) return;
 
-            if (!category || !category.is_active) {
-              return result;
-            }
-
-            return result.concat({
-              id: category.id,
-              name: category.name,
-              link: formatCategoryLink(category),
-              count: category.product_count,
-              position: category.position,
-              items: this.prepareCategories(subCategory.children_data, [
-                {
-                  id: category.id,
-                  name: i18n.t('View all'),
-                  link: formatCategoryLink(category),
-                  count: category.product_count,
-                  position: 0
-                }
-              ])
-            });
-          }, firstItem)
-          .sort((a, b) => a.position - b.position)
-        : firstItem;
+      return {
+        id: category.id,
+        name: category.name,
+        link: formatCategoryLink(category),
+        count: category.product_count || '',
+        position: category.position
+      };
     },
     prepareCategoryProduct (product) {
       return {

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -317,14 +317,18 @@ export default {
             position: 0
           };
 
+          const subCategories = category.children_data
+            ? category.children_data
+              .map(subCategory => this.prepareCategoryMenuItem(
+                this.getCategories.find(category => category.id === subCategory.id)
+              ))
+              .filter(Boolean)
+            : [];
+
           return {
             ...this.prepareCategoryMenuItem(category),
             items: [this.prepareCategoryMenuItem(viewAllMenuItem)]
-              .concat(
-                category.children_data.map(childCategory => this.prepareCategoryMenuItem(
-                  this.getCategories.find(category => category.id === childCategory.id)
-                ))
-              )
+              .concat(subCategories)
               .sort((a, b) => a.position - b.position)
           };
         })


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #172 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This change unifies categories in header and in the sidebar. Also number of products in given category is not shown if `product_count` is 0 - the same as in _Filters_ sidebar.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![categories](https://user-images.githubusercontent.com/56868128/74738327-f20fac80-5256-11ea-9215-efdc3d823400.png)

![categories](https://user-images.githubusercontent.com/56868128/74739109-7f9fcc00-5258-11ea-92d7-7438b09c1a02.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)