### PR TITLE
Don't use latest Storefront UI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@storefront-ui/vue": "latest",
+    "@storefront-ui/vue": "^0.5.1",
     "body-scroll-lock": "^2.6.4",
     "supports-webp": "^2.0.1",
     "vue": "^2.6.6",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR changes Storefront UI version we are using. It is safer not to stick with always "latest" library version, especially if "breaking changes" are announced in advance in 0.6.0.
Version **^0.5.1** means >**=0.5.1** and <**0.6.0**

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)