### PR TITLE
Add bottom navigation on mobile view

### DIFF
--- a/components/atoms/a-home-icon.vue
+++ b/components/atoms/a-home-icon.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="a-home-icon">
+    <SfCircleIcon
+      icon="home"
+      icon-size="20px"
+      icon-color="black"
+      class="sf-header__icon"
+      role="button"
+      :aria-label="$t('Return to home')"
+      @click="$router.push(localizedRoute('/'))"
+    />
+  </div>
+</template>
+
+<script>
+import { SfCircleIcon } from '@storefront-ui/vue';
+
+export default {
+  name: 'AHomeIcon',
+  components: {
+    SfCircleIcon
+  }
+};
+</script>

--- a/components/atoms/a-microcart-icon.vue
+++ b/components/atoms/a-microcart-icon.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="a-microcart-icon">
     <SfCircleIcon
-      icon="empty_cart"
       icon-size="20px"
-      icon-color="black"
-      class="sf-header__icon"
+      :icon="floatingIcon ? 'add_to_cart' : 'empty_cart'"
+      :icon-color="floatingIcon ? 'white' : 'black'"
+      :class="floatingIcon ? 'sf-bottom-navigation__floating-icon' : 'sf-header__icon'"
       role="button"
       :aria-label="$t('Open microcart')"
       @click="openMicrocart"
     />
-    <SfBadge v-show="totalQuantity" class="badge">
+    <SfBadge v-show="!floatingIcon && totalQuantity" class="badge">
       {{ totalQuantity }}
     </SfBadge>
   </div>
@@ -21,6 +21,12 @@ import { SfCircleIcon, SfBadge } from '@storefront-ui/vue';
 
 export default {
   components: { SfCircleIcon, SfBadge },
+  props: {
+    floatingIcon: {
+      type: Boolean,
+      default: false
+    }
+  },
   computed: {
     ...mapGetters({
       totalQuantity: 'cart/getItemsTotalQuantity'

--- a/components/organisms/o-bottom-navigation.vue
+++ b/components/organisms/o-bottom-navigation.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="o-bottom-navigation" :style="{'z-index': isBottomNavigationOnTop ? 1 : 0}">
+    <SfBottomNavigation>
+      <SfBottomNavigationItem v-for="(item, index) in navigationItems" :key="index">
+        <component :is="item.component" v-bind="item.props" />
+      </SfBottomNavigationItem>
+    </SfBottomNavigation>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import AHomeIcon from 'theme/components/atoms/a-home-icon';
+import ASearchIcon from 'theme/components/atoms/a-search-icon';
+import AAccountIcon from 'theme/components/atoms/a-account-icon';
+import AMicrocartIcon from 'theme/components/atoms/a-microcart-icon';
+import { SfBottomNavigation } from '@storefront-ui/vue';
+
+export default {
+  name: 'OBottomNavigation',
+  components: {
+    SfBottomNavigation,
+    AHomeIcon,
+    ASearchIcon,
+    AAccountIcon,
+    AMicrocartIcon
+  },
+  data () {
+    return {
+      navigationItems: [
+        { component: AHomeIcon },
+        { component: ASearchIcon },
+        { component: AAccountIcon },
+        { component: AMicrocartIcon, props: { floatingIcon: true } }
+      ]
+    }
+  },
+  computed: {
+    ...mapState({
+      isSidebarVisible: state => state.ui.sidebar,
+      isMicrocartVisible: state => state.ui.microcart,
+      isSearchPanelVisible: state => state.ui.searchpanel,
+      isOverlayVisible: state => state.ui.overlay,
+      isLoaderVisible: state => state.ui.loader,
+      isModalVisible: state => state.ui.modal.activeModals.length > 0
+    }),
+    isBottomNavigationOnTop () {
+      return !this.isSidebarVisible &&
+        !this.isMicrocartVisible &&
+        !this.isSearchPanelVisible &&
+        !this.isOverlayVisible &&
+        !this.isLoaderVisible &&
+        !this.isModalVisible;
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/_variables.scss";
+
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+
+.o-bottom-navigation {
+  @include for-desktop() {
+    display: none;
+  }
+}
+</style>

--- a/components/organisms/o-footer.vue
+++ b/components/organisms/o-footer.vue
@@ -51,13 +51,15 @@
         </div>
       </SfFooterColumn>
     </SfFooter>
-    <ABackToTop bottom="20px" right="20px" visibleoffset="200" />
+    <!-- temporarily disabled until we find better UI/UX for it ;)
+      <ABackToTop bottom="20px" right="20px" visibleoffset="200" />
+    -->
   </footer>
 </template>
 
 <script>
 import LanguageSwitcher from 'theme/components/core/blocks/Switcher/LanguageSwitcher';
-import ABackToTop from 'theme/components/atoms/a-back-to-top';
+// import ABackToTop from 'theme/components/atoms/a-back-to-top';
 import { SfFooter, SfList, SfMenuItem } from '@storefront-ui/vue';
 import { getPathForStaticPage } from 'theme/helpers';
 import config from 'config';
@@ -67,7 +69,7 @@ export default {
   name: 'MainFooter',
   components: {
     LanguageSwitcher,
-    ABackToTop,
+    // ABackToTop,
     SfFooter,
     SfList,
     SfMenuItem

--- a/layouts/Default.vue
+++ b/layouts/Default.vue
@@ -28,6 +28,7 @@
         v-if="loadOrderConfirmation"
         :orders-data="ordersData"
       />
+      <OBottomNavigation />
     </div>
     <vue-progress-bar />
   </div>
@@ -39,6 +40,7 @@ import AsyncSidebar from 'theme/components/theme/blocks/AsyncSidebar/AsyncSideba
 import OHeader from 'theme/components/organisms/o-header';
 import OFooter from 'theme/components/organisms/o-footer';
 import OModal from 'theme/components/organisms/o-modal';
+import OBottomNavigation from 'theme/components/organisms/o-bottom-navigation';
 import Loader from 'theme/components/core/Loader';
 import Notification from 'theme/components/core/Notification';
 import CookieNotification from 'theme/components/core/CookieNotification';
@@ -68,6 +70,7 @@ export default {
     OfflineBadge,
     OMicrocart,
     OrderConfirmation,
+    OBottomNavigation,
     AsyncSidebar,
     SfSidebar,
     OModal


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #188 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR introduces bottom navigation for mobile view and it contains the following links:
- back to home,
- open search sidebar,
- open account modal
- open cart sidebar (as big green floating icon).

The 'back to top' floating icon has been removed temporarily.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![bottom-navigation](https://user-images.githubusercontent.com/56868128/75021563-ead5e200-5494-11ea-9cbd-0c51e9624ada.png)


![bottom-navigation](https://user-images.githubusercontent.com/56868128/75021575-ee696900-5494-11ea-9ff2-a3e61e35986a.gif)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)