### PR TITLE
Center 'Read all review' link with star ratings

### DIFF
--- a/components/atoms/a-product-rating.vue
+++ b/components/atoms/a-product-rating.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="a-product-rating">
     <SfRating :score="score" :max="max" @click="$emit('click:stars')" />
-    <ATextAction :text="text" class="action" @click="$emit('click:text')">
+    <ATextAction :text="text" @click="$emit('click:text')">
       <slot />
     </ATextAction>
   </div>
@@ -50,6 +50,7 @@ export default {
 }
 .a-product-rating {
   display: flex;
+  align-items: center;
   margin-top: $spacer-big / 2;
   @include for-desktop {
     margin-left: auto;
@@ -57,12 +58,8 @@ export default {
   ::v-deep .sf-rating {
     cursor: pointer;
   }
-}
-.action {
-  margin: 0;
-  ::v-deep .sf-action {
-    line-height: 1;
-    padding-bottom: 5px;
+  ::v-deep .a-text-action {
+    margin: 0;
   }
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #189 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This was a very interesting bug to investigate  😅 

It turned out that this bug depends on a random hash fragment in `data-v-[hash]` attributes in our components with scoped styles. These scoped styles are always applied in alphabetical order and this was the reason that sometimes (i.e. in my local development builds) this bug was not present.

I fixed that by increasing CSS specificity to be sure that our styles are always applied in expected order.

### Detailed explanation
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

In one build (in this case in production on capybara.storefrontcloud.io) this bug exists because parent element `.a-product-rating` has `data-v-54adf582` and child `.a-text-action` has `data-v-f3ca352e`. Scope styles assigned to these attributes are applied in alphabetical order: **first from parent** `data-v-54adf582` and **then from child** `data-v-f3ca352e` - see on the right panel. It causes that `margin` rule is overwritten.
![prod-build](https://user-images.githubusercontent.com/56868128/75031488-a5baab80-54a6-11ea-96d0-8922e13e640b.png)

In another build (in this case in my local development environment) this bug **does not** exist because parent element `.a-product-rating` has `data-v-f3e6c262` and child `.a-text-action` has `data-v-4f48c272`. Scope styles are applied also in alphabetical order: **first from child** `data-v-4f48c272` and **then from parent** `data-v-f3e6c262` but in this case random hashes are applied in expected order.
![dev-build](https://user-images.githubusercontent.com/56868128/75031493-a94e3280-54a6-11ea-8496-0820b178d879.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)