### PR TITLE
webpack optimizations - move all node_modules libs to vendor

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,17 +47,20 @@ function fixPostCSSPlugins (rules) {
 }
 
 module.exports = function (config, { isClient }) {
+  const sfuiCacheGroup = '@storefront-ui|@glidejs';
   const clientConfig = isClient ? {
     optimization: {
       splitChunks: {
         cacheGroups: {
           commons: {
-            test: /[\\/]node_modules[\\/](vue|vuex|vue-router|vue-meta|vue-i18n|vuex-router-sync|localforage|lean-he|vue-lazyload|js-sha3|dayjs|core-js|whatwg-fetch|vuelidate)[\\/]/,
+            // create 'vendor' group from all packages from node_modules except Storefront UI
+            test: new RegExp(`[\\\\/]node_modules[\\\\/](?!(${sfuiCacheGroup}))`),
             name: 'vendor',
             chunks: 'all'
           },
           sfui: {
-            test: /[\\/]node_modules[\\/][\\@](storefront[\\-]ui|glidejs)/,
+            // create 'sfui' group from Storefront UI only
+            test: new RegExp(`[\\\\/]node_modules[\\\\/](${sfuiCacheGroup})`),
             name: 'sfui',
             chunks: 'all'
           }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #110 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR cleans up our bundles: it moves all libs from `node_modules` to `vendor` chunk - except Storefront UI which has own `sfui` chunk as before. The total size of all chunks is decreased by ~10 KB.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:

![before](https://user-images.githubusercontent.com/56868128/75148602-51126d00-5700-11ea-97e6-055941cabfbe.png)

After:

![after](https://user-images.githubusercontent.com/56868128/75148608-553e8a80-5700-11ea-88e1-b43878dc0a07.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)