### PR TITLE
Fixed z-index for bottom navigation

### DIFF
--- a/components/organisms/o-bottom-navigation.vue
+++ b/components/organisms/o-bottom-navigation.vue
@@ -68,5 +68,8 @@ export default {
   @include for-desktop() {
     display: none;
   }
+  ::v-deep .sf-bottom-navigation {
+    z-index: inherit;
+  }
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #188

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This fixes `z-index` for bottom navigation if there is a modal or sidebar opened. Bottom navigation was rendered "above" overlay or sidebar which did not look nice.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

![before](https://user-images.githubusercontent.com/56868128/75149725-f62e4500-5702-11ea-9e0f-812fad17e8d7.png)

After:

![after](https://user-images.githubusercontent.com/56868128/75149731-f7f80880-5702-11ea-92bb-266ca240656e.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)