### PR TITLE
Fixed filter sidebar if filters are missing

### DIFF
--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -372,7 +372,7 @@ export default {
       return selectedSortOrder.label || ''
     },
     availableFilters () {
-      return Object.entries(this.getAvailableFilters)
+      return Object.entries(this.getAvailableFilters || {})
         .filter(([filterType, filters]) => {
           return (
             filters.length && !this.getSystemFilterNames.includes(filterType)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
No related issue.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This change prevents from crashing if `category-next/getAvailableFilters` is not available.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)