### PR TITLE
create async and initial vendor

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,10 +53,16 @@ module.exports = function (config, { isClient }) {
       splitChunks: {
         cacheGroups: {
           commons: {
-            // create 'vendor' group from all packages from node_modules except Storefront UI
+            // create 'vendor' group from initial packages from node_modules except Storefront UI
             test: new RegExp(`[\\\\/]node_modules[\\\\/](?!(${sfuiCacheGroup}))`),
-            name: 'vendor',
-            chunks: 'all'
+            name: 'vendor-initial',
+            chunks: 'initial'
+          },
+          async: {
+            // create 'vendor' group from async packages from node_modules except Storefront UI
+            test: new RegExp(`[\\\\/]node_modules[\\\\/](?!(${sfuiCacheGroup}))`),
+            name: 'vendor-async',
+            chunks: 'async'
           },
           sfui: {
             // create 'sfui' group from Storefront UI only


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In this change we split vendor into initial chunk and async chunk. Size of bundle didn't change. Purpose of this change is that we will load on preload libs that are needed and rest in prefetch. So vendor-initial is smaller then previous vendor

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
before:
![Zrzut ekranu z 2020-02-25 07-06-38](https://user-images.githubusercontent.com/42383376/75219725-e6177380-579d-11ea-8da4-7cfd280e3afe.png)
After:
![Zrzut ekranu z 2020-02-25 07-04-11](https://user-images.githubusercontent.com/42383376/75219736-ec0d5480-579d-11ea-97d2-44681afd9d58.png)


Bundle before:
![Zrzut ekranu z 2020-02-25 07-12-18](https://user-images.githubusercontent.com/42383376/75219843-30005980-579e-11ea-9cfd-1f0ff497a8ee.png)

Bundle after:
![Zrzut ekranu z 2020-02-25 07-12-23](https://user-images.githubusercontent.com/42383376/75219847-355da400-579e-11ea-9ad6-f54dd61a47a7.png)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)