### PR TITLE
Handle Enter key in login and register forms

### DIFF
--- a/components/molecules/m-login.vue
+++ b/components/molecules/m-login.vue
@@ -1,38 +1,40 @@
 <template>
   <div class="m-login" key="log-in">
     <div class="form">
-      <SfInput
-        v-model="email"
-        name="email"
-        :label="$t('Your email')"
-        :required="true"
-        :valid="!$v.email.$error"
-        :error-message="
-          !$v.email.required
-            ? $t('Field is required.')
-            : $t('Please provide valid e-mail address.')
-        "
-        class="form__input"
-      />
-      <SfInput
-        v-model="password"
-        name="password"
-        :label="$t('Password')"
-        :required="true"
-        :valid="!$v.password.$error"
-        :error-message="$t('Field is required.')"
-        type="password"
-        class="form__input"
-      />
-      <SfCheckbox
-        v-model="rememberMe"
-        name="remember-me"
-        :label="$t('Remember me')"
-        class="form__checkbox"
-      />
-      <SfButton class="sf-button--full-width form__button" @click.native="login">
-        {{ $t("Login") }}
-      </SfButton>
+      <form @submit.prevent="login">
+        <SfInput
+          v-model="email"
+          name="email"
+          :label="$t('Your email')"
+          :required="true"
+          :valid="!$v.email.$error"
+          :error-message="
+            !$v.email.required
+              ? $t('Field is required.')
+              : $t('Please provide valid e-mail address.')
+          "
+          class="form__input"
+        />
+        <SfInput
+          v-model="password"
+          name="password"
+          :label="$t('Password')"
+          :required="true"
+          :valid="!$v.password.$error"
+          :error-message="$t('Field is required.')"
+          type="password"
+          class="form__input"
+        />
+        <SfCheckbox
+          v-model="rememberMe"
+          name="remember-me"
+          :label="$t('Remember me')"
+          class="form__checkbox"
+        />
+        <SfButton class="sf-button--full-width form__button" @click.native="login">
+          {{ $t("Login") }}
+        </SfButton>
+      </form>
     </div>
     <div class="action">
       <SfButton class="sf-button--text button--muted" @click.native="switchElem('forgot-pass')">

--- a/components/molecules/m-register.vue
+++ b/components/molecules/m-register.vue
@@ -1,59 +1,61 @@
 <template>
   <div class="m-register form" key="sign-up">
     <div class="from">
-      <SfInput
-        v-model="email"
-        name="email"
-        :label="$t('Your email')"
-        :required="true"
-        :valid="!$v.email.$error"
-        :error-message="
-          !$v.email.required
-            ? $t('Field is required.')
-            : $t('Please provide valid e-mail address.')
-        "
-        class="form__input"
-      />
-      <SfInput
-        v-model="firstName"
-        name="first-name"
-        :label="$t('First Name')"
-        :required="true"
-        :valid="!$v.firstName.$error"
-        :error-message="$t('Field is required.')"
-        class="form__input"
-      />
-      <SfInput
-        v-model="lastName"
-        name="last-name"
-        :label="$t('Last Name')"
-        :required="true"
-        :valid="!$v.lastName.$error"
-        :error-message="$t('Field is required.')"
-        class="form__input"
-      />
-      <SfInput
-        v-model="password"
-        name="password"
-        :label="$t('Password')"
-        :required="true"
-        :valid="!$v.password.$error"
-        :error-message="$t('Field is required.')"
-        type="password"
-        class="form__input"
-      />
-      <SfCheckbox
-        v-model="createAccount"
-        name="create-account"
-        :label="$t('I want to create an account')"
-        class="form__checkbox"
-      />
-      <SfButton
-        class="sf-button--full-width form__button"
-        @click.native="register"
-      >
-        {{ $t("Create an account") }}
-      </SfButton>
+      <form @submit.prevent="register">
+        <SfInput
+          v-model="email"
+          name="email"
+          :label="$t('Your email')"
+          :required="true"
+          :valid="!$v.email.$error"
+          :error-message="
+            !$v.email.required
+              ? $t('Field is required.')
+              : $t('Please provide valid e-mail address.')
+          "
+          class="form__input"
+        />
+        <SfInput
+          v-model="firstName"
+          name="first-name"
+          :label="$t('First Name')"
+          :required="true"
+          :valid="!$v.firstName.$error"
+          :error-message="$t('Field is required.')"
+          class="form__input"
+        />
+        <SfInput
+          v-model="lastName"
+          name="last-name"
+          :label="$t('Last Name')"
+          :required="true"
+          :valid="!$v.lastName.$error"
+          :error-message="$t('Field is required.')"
+          class="form__input"
+        />
+        <SfInput
+          v-model="password"
+          name="password"
+          :label="$t('Password')"
+          :required="true"
+          :valid="!$v.password.$error"
+          :error-message="$t('Field is required.')"
+          type="password"
+          class="form__input"
+        />
+        <SfCheckbox
+          v-model="createAccount"
+          name="create-account"
+          :label="$t('I want to create an account')"
+          class="form__checkbox"
+        />
+        <SfButton
+          class="sf-button--full-width form__button"
+          @click.native="register"
+        >
+          {{ $t("Create an account") }}
+        </SfButton>
+      </form>
     </div>
     <div class="action">
       {{ $t("or") }}

--- a/components/molecules/m-reset-password.vue
+++ b/components/molecules/m-reset-password.vue
@@ -4,22 +4,24 @@
       <p class="form__message">
         {{ $t('Enter your email to receive instructions on how to reset your password.') }}
       </p>
-      <SfInput
-        v-model="email"
-        name="email"
-        :label="$t('Your email')"
-        :required="true"
-        :valid="!$v.email.$error"
-        :error-message="
-          !$v.email.required
-            ? $t('Field is required.')
-            : $t('Please provide valid e-mail address.')
-        "
-        class="form__input"
-      />
-      <SfButton class="sf-button--full-width form__button" @click.native="resetPassword">
-        {{ $t("Reset password") }}
-      </SfButton>
+      <form @submit.prevent="resetPassword">
+        <SfInput
+          v-model="email"
+          name="email"
+          :label="$t('Your email')"
+          :required="true"
+          :valid="!$v.email.$error"
+          :error-message="
+            !$v.email.required
+              ? $t('Field is required.')
+              : $t('Please provide valid e-mail address.')
+          "
+          class="form__input"
+        />
+        <SfButton class="sf-button--full-width form__button" @click.native="resetPassword">
+          {{ $t("Reset password") }}
+        </SfButton>
+      </form>
     </div>
     <div v-else>
       <p class="form__message">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #199

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This change allows submitting login, register and password reset forms by pressing Enter key.

**Remark**: currently there is a bug in Storefront UI https://github.com/DivanteLtd/storefront-ui/issues/782 which causes that clicking on "Show password" icon in password input triggers `submit` event, because by default buttons without type within forms are assumed to be of type `submit`.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)