### PR TITLE
webpack cleanup and optimizations

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,28 +47,37 @@ function fixPostCSSPlugins (rules) {
 }
 
 module.exports = function (config, { isClient }) {
-  const sfuiCacheGroup = '@storefront-ui|@glidejs';
   const clientConfig = isClient ? {
     optimization: {
       splitChunks: {
+        chunks: 'all',
         cacheGroups: {
-          commons: {
-            // create 'vendor' group from initial packages from node_modules except Storefront UI
-            test: new RegExp(`[\\\\/]node_modules[\\\\/](?!(${sfuiCacheGroup}))`),
-            name: 'vendor-initial',
-            chunks: 'initial'
-          },
-          async: {
-            // create 'vendor' group from async packages from node_modules except Storefront UI
-            test: new RegExp(`[\\\\/]node_modules[\\\\/](?!(${sfuiCacheGroup}))`),
-            name: 'vendor-async',
-            chunks: 'async'
-          },
+          // cache groups are handled basing on priority - given module will belong to the cache group with a higher priority
           sfui: {
             // create 'sfui' group from Storefront UI only
-            test: new RegExp(`[\\\\/]node_modules[\\\\/](${sfuiCacheGroup})`),
+            test: /@storefront-ui|@glidejs/,
             name: 'sfui',
-            chunks: 'all'
+            priority: 2
+          },
+          vendorInitial: {
+            // create 'vendor' group from initial packages from node_modules except Storefront UI
+            test: /node_modules/,
+            name: 'vendor-initial',
+            chunks: 'initial',
+            priority: 1
+          },
+          vendorAsync: {
+            // create 'vendor' group from async packages from node_modules except Storefront UI
+            test: /node_modules/,
+            name: 'vendor-async',
+            chunks: 'async',
+            priority: 1
+          },
+          searchAdapter: {
+            // create one 'vsf-search-adapter' group
+            test: /vsf-search-adapter/,
+            name: 'vsf-search-adapter',
+            priority: 1
           }
         }
       }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #110 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This change simplifies webpack config a little bit and it also enforces to create only one `vsf-search-adapter` file. Previously there were `vsf-search-adapter-0` and `vsf-search-adapter-1`.

After changes:

![webpack](https://user-images.githubusercontent.com/56868128/75251869-c2731e00-57db-11ea-9fc2-5f6698b3f553.png)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)