### PR TITLE
Bottom navigation on mobile is shown on top of sidebar

### DIFF
--- a/layouts/Default.vue
+++ b/layouts/Default.vue
@@ -139,6 +139,8 @@ export default {
 <style lang="scss">
 @import "~@storefront-ui/vue/styles";
 body {
+  --overlay-z-index: 10;
+  --sidebar-aside-z-index: 11;
   color: var(--c-text);
   font-size: var(--font-size-regular);
   font-family: var(--body-font-family-secondary);

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -169,7 +169,6 @@ import { getSearchOptionsFromRouteParams } from '@vue-storefront/core/modules/ca
 import { catalogHooksExecutors } from '@vue-storefront/core/modules/catalog-next/hooks';
 import { getTopLevelCategories } from 'theme/helpers';
 import AIconFilter from 'theme/components/atoms/a-icon-filter';
-import AIconSort from 'theme/components/atoms/a-icon-sort';
 import AIconViewGrid from 'theme/components/atoms/a-icon-view-grid';
 import AIconViewRow from 'theme/components/atoms/a-icon-view-row';
 import {
@@ -233,7 +232,6 @@ export default {
   name: 'CategoryPage',
   components: {
     LazyHydrate,
-    AIconSort,
     AIconFilter,
     AIconViewRow,
     AIconViewGrid,
@@ -780,6 +778,9 @@ export default {
   }
   &__buttons {
     margin: calc(var(--spacer-big) * 3) 0 0 0;
+    @include for-mobile {
+      margin: calc(var(--spacer-big) * 3) 0;
+    }
   }
   &__button-clear {
     --button-background: var(--c-light);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #236

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes overlapping _Filters_ sidebar by bottom navigation on mobile view. It also fixes bottom buttons in _Filters_ sidebar - they were cut on the bottom.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![zrzut 2020-03-04 09 36 24](https://user-images.githubusercontent.com/56868128/75860853-c9fa7e80-5dfc-11ea-82f1-3b9f2db28aba.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)