### PR TITLE
Bottom button in cart sidebar is cut on mobile view

### DIFF
--- a/components/organisms/o-microcart.vue
+++ b/components/organisms/o-microcart.vue
@@ -43,7 +43,7 @@
           <SfPrice :regular="total | price" class="sf-price--big" />
         </template>
       </SfProperty>
-      <SfButton class="sf-button--full-width" @click.native="goToCheckout">
+      <SfButton class="sf-button--full-width cart-action" @click.native="goToCheckout">
         {{ $t("Go to checkout") }}
       </SfButton>
     </div>
@@ -66,7 +66,7 @@
         </p>
       </div>
       <SfButton
-        class="sf-button--full-width color-secondary"
+        class="sf-button--full-width color-secondary cart-action"
         @click.native="startShopping"
       >
         {{ $t("Start shopping") }}
@@ -236,6 +236,11 @@ export default {
   }
   &__description {
     margin-top: var(--spacer-big);
+  }
+}
+@include for-mobile {
+  .cart-action {
+    margin-bottom: var(--spacer-big);
   }
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #238

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes bottom button in cart sidebar on mobile view - button is no longer cut on the bottom.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![zrzut 2020-03-04 09 53 53](https://user-images.githubusercontent.com/56868128/75861883-4cd00900-5dfe-11ea-90ae-a5f9d8ece567.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)