### PR TITLE
Decrease bundle size by removing unneeded Storefront UI dependencies

### DIFF
--- a/components/atoms/a-images-grid.vue
+++ b/components/atoms/a-images-grid.vue
@@ -45,10 +45,10 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .a-images-grid {
-    max-width: 60rem;
+  max-width: 60rem;
   margin: 0 auto;
   &__row {
     display: flex;

--- a/components/atoms/a-product-attribute.vue
+++ b/components/atoms/a-product-attribute.vue
@@ -18,7 +18,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .a-product-attribute {
   padding: var(--spacer-small) 0;
 }

--- a/components/atoms/a-product-rating.vue
+++ b/components/atoms/a-product-rating.vue
@@ -41,7 +41,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .a-product-rating {
   display: flex;

--- a/components/atoms/a-promo-code.vue
+++ b/components/atoms/a-promo-code.vue
@@ -64,7 +64,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .promo-code {
   &__button {
     padding: 0;

--- a/components/atoms/a-text-action.vue
+++ b/components/atoms/a-text-action.vue
@@ -19,8 +19,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
-
 .a-text-action {
   display: flex;
   margin: var(--spacer-big) 0 (var(--spacer-big) / 2);

--- a/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -139,7 +139,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 .searchpanel {
   height: 100vh;
   right: 0;

--- a/components/molecules/m-error.vue
+++ b/components/molecules/m-error.vue
@@ -44,7 +44,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .error {
   margin: auto;

--- a/components/molecules/m-login.vue
+++ b/components/molecules/m-login.vue
@@ -142,7 +142,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 .form {
   &__input {
     margin-bottom: var(--spacer-extra-big);

--- a/components/molecules/m-price-summary.vue
+++ b/components/molecules/m-price-summary.vue
@@ -52,7 +52,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .property {
   margin-bottom: var(--spacer);
   ::v-deep .sf-property__name {

--- a/components/molecules/m-product-additional-info.vue
+++ b/components/molecules/m-product-additional-info.vue
@@ -81,7 +81,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .m-product-additional-info {
   margin-top: var(--spacer-big);

--- a/components/molecules/m-product-call-to-action.vue
+++ b/components/molecules/m-product-call-to-action.vue
@@ -98,7 +98,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .m-product-call-to-action {
   display: flex;

--- a/components/molecules/m-product-gallery.vue
+++ b/components/molecules/m-product-gallery.vue
@@ -117,7 +117,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .m-product-gallery {
   flex: 1;
 }

--- a/components/molecules/m-product-options-configurable.vue
+++ b/components/molecules/m-product-options-configurable.vue
@@ -92,7 +92,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .m-product-options-configurable {
   border-bottom: 1px solid #f1f2f3;

--- a/components/molecules/m-product-short-info.vue
+++ b/components/molecules/m-product-short-info.vue
@@ -81,7 +81,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .description {
   margin: var(--spacer-extra-big) 0 calc(var(--spacer-big) * 3) 0;

--- a/components/molecules/m-register.vue
+++ b/components/molecules/m-register.vue
@@ -172,7 +172,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .form {
   &__input {
     margin-bottom: var(--spacer-extra-big);

--- a/components/molecules/m-reset-password.vue
+++ b/components/molecules/m-reset-password.vue
@@ -107,7 +107,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .form {
   &__input {
     margin-bottom: var(--spacer-extra-big);

--- a/components/molecules/m-review-list.vue
+++ b/components/molecules/m-review-list.vue
@@ -62,7 +62,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .record {
   padding-bottom: var(--spacer-big);

--- a/components/molecules/m-update-password.vue
+++ b/components/molecules/m-update-password.vue
@@ -104,7 +104,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .form {
   @include for-desktop {

--- a/components/molecules/m-update-personal-data.vue
+++ b/components/molecules/m-update-personal-data.vue
@@ -108,7 +108,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .form {
   @include for-desktop {

--- a/components/molecules/modals/m-modal-account-benefits.vue
+++ b/components/molecules/modals/m-modal-account-benefits.vue
@@ -82,7 +82,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .m-modal-account-benefits {
   line-height: 1;
 }

--- a/components/molecules/modals/m-modal-newsletter.vue
+++ b/components/molecules/modals/m-modal-newsletter.vue
@@ -38,8 +38,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
-
 .message {
   margin: 0 0 var(--spacer-extra-big) 0;
   font-size: var(--font-size-regular);

--- a/components/molecules/modals/m-modal-review.vue
+++ b/components/molecules/modals/m-modal-review.vue
@@ -160,8 +160,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
-
 .form {
   &__input {
     margin-bottom: var(--spacer-extra-big);

--- a/components/molecules/modals/m-modal-terms-and-conditions.vue
+++ b/components/molecules/modals/m-modal-terms-and-conditions.vue
@@ -85,7 +85,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
 .modal {
   cursor: default;
   &__heading {

--- a/components/organisms/o-bottom-navigation.vue
+++ b/components/organisms/o-bottom-navigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="o-bottom-navigation" :style="{'z-index': isBottomNavigationOnTop ? 1 : 0}">
+  <div class="o-bottom-navigation">
     <SfBottomNavigation>
       <SfBottomNavigationItem
         v-for="(item, index) in navigationItems"
@@ -40,21 +40,8 @@ export default {
   computed: {
     ...mapGetters('user', ['isLoggedIn']),
     ...mapState({
-      isSidebarVisible: state => state.ui.sidebar,
-      isMicrocartVisible: state => state.ui.microcart,
-      isSearchPanelVisible: state => state.ui.searchpanel,
-      isOverlayVisible: state => state.ui.overlay,
-      isLoaderVisible: state => state.ui.loader,
-      isModalVisible: state => state.ui.modal.activeModals.length > 0
-    }),
-    isBottomNavigationOnTop () {
-      return !this.isSidebarVisible &&
-        !this.isMicrocartVisible &&
-        !this.isSearchPanelVisible &&
-        !this.isOverlayVisible &&
-        !this.isLoaderVisible &&
-        !this.isModalVisible;
-    }
+      isSearchPanelVisible: state => state.ui.searchpanel
+    })
   },
   methods: {
     ...mapActions({
@@ -81,7 +68,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .o-bottom-navigation {
   @include for-desktop() {

--- a/components/organisms/o-confirm-order.vue
+++ b/components/organisms/o-confirm-order.vue
@@ -305,7 +305,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .title {
   margin-bottom: var(--spacer-extra-big);

--- a/components/organisms/o-footer.vue
+++ b/components/organisms/o-footer.vue
@@ -123,7 +123,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .o-footer {
   @include for-desktop {

--- a/components/organisms/o-header.vue
+++ b/components/organisms/o-header.vue
@@ -69,7 +69,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .o-header {
   box-sizing: border-box;

--- a/components/organisms/o-microcart.vue
+++ b/components/organisms/o-microcart.vue
@@ -174,7 +174,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #cart {
   box-sizing: border-box;

--- a/components/organisms/o-modal.vue
+++ b/components/organisms/o-modal.vue
@@ -42,7 +42,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .modal {
   box-sizing: border-box;

--- a/components/organisms/o-my-account-orders-history.vue
+++ b/components/organisms/o-my-account-orders-history.vue
@@ -108,7 +108,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .message {
   margin: 0 0 var(--spacer-extra-big) 0;

--- a/components/organisms/o-my-account-placeholder.vue
+++ b/components/organisms/o-my-account-placeholder.vue
@@ -24,7 +24,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .message {
   margin: 0 0 var(--spacer-extra-big) 0;

--- a/components/organisms/o-my-account-shipping-details.vue
+++ b/components/organisms/o-my-account-shipping-details.vue
@@ -302,7 +302,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .form {
   @include for-desktop {

--- a/components/organisms/o-notification.vue
+++ b/components/organisms/o-notification.vue
@@ -52,7 +52,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 @import "~theme/css/base/global_vars";
 $z-index-notification: map-get($z-index, notification);
 

--- a/components/organisms/o-order-confirmation.vue
+++ b/components/organisms/o-order-confirmation.vue
@@ -165,7 +165,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #o-order-confirmation {
   box-sizing: border-box;

--- a/components/organisms/o-order-review.vue
+++ b/components/organisms/o-order-review.vue
@@ -124,8 +124,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
-
 .highlighted {
   box-sizing: border-box;
   width: 100%;

--- a/components/organisms/o-order-summary.vue
+++ b/components/organisms/o-order-summary.vue
@@ -157,8 +157,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
-
 .highlighted {
   box-sizing: border-box;
   width: 100%;

--- a/components/organisms/o-payment.vue
+++ b/components/organisms/o-payment.vue
@@ -282,7 +282,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .title {
   margin-bottom: var(--spacer-extra-big);

--- a/components/organisms/o-personal-details.vue
+++ b/components/organisms/o-personal-details.vue
@@ -203,7 +203,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .title {
   margin-bottom: var(--spacer-extra-big);

--- a/components/organisms/o-product-details.vue
+++ b/components/organisms/o-product-details.vue
@@ -173,7 +173,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .o-product-details {
   @include for-desktop {

--- a/components/organisms/o-shipping.vue
+++ b/components/organisms/o-shipping.vue
@@ -217,7 +217,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .title {
   margin-bottom: var(--spacer-extra-big);

--- a/layouts/Default.vue
+++ b/layouts/Default.vue
@@ -164,7 +164,7 @@ export default {
 
 <style lang="scss" src="theme/css/main.scss"></style>
 <style lang="scss">
-@import "~@storefront-ui/shared/styles/helpers";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 body {
   --overlay-z-index: 1;
   --sidebar-aside-z-index: 2;

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -572,7 +572,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #category {
   box-sizing: border-box;

--- a/pages/Checkout.vue
+++ b/pages/Checkout.vue
@@ -131,7 +131,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #checkout {
   box-sizing: border-box;

--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -176,7 +176,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #home {
   box-sizing: border-box;

--- a/pages/MyAccount.vue
+++ b/pages/MyAccount.vue
@@ -96,7 +96,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #my-account {
   box-sizing: border-box;

--- a/pages/Product.vue
+++ b/pages/Product.vue
@@ -244,7 +244,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 .breadcrumbs {
   padding: var(--spacer-big) var(--spacer-extra-big) var(--spacer-extra-big);

--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -133,7 +133,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@storefront-ui/vue/styles";
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
 #static {
   box-sizing: border-box;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #110 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR significantly decreases total bundle size by removing unneeded Storefront UI dependencies from various components. Comparing current bundle size with that before Storefront UI 0.6.x integration, it has been reduced by +20% - and it still works  😄 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![webpack](https://user-images.githubusercontent.com/56868128/76078971-0ddbb800-5fa4-11ea-928b-a9eed9272d02.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)