### PR TITLE
#220 Download all orders

### DIFF
--- a/components/molecules/modals/m-modal-feature-not-implemented.vue
+++ b/components/molecules/modals/m-modal-feature-not-implemented.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="m-modal-newsletter">
+  <div class="m-modal-feature-not-implemented">
     <SfModal :visible="isVisible" @close="$emit('close', modalData.name)">
       <p class="message">
         {{ $t('This feature is not implemented yet! Please take a look at') }}<br>

--- a/components/organisms/o-my-account-orders-history.vue
+++ b/components/organisms/o-my-account-orders-history.vue
@@ -26,7 +26,7 @@
             </SfTableHeader>
             <SfTableHeader>
               <span class="mobile-only">{{ $t('Download') }}</span>
-              <SfButton class="desktop-only orders__download-all">
+              <SfButton @click.native="downloadAll" class="desktop-only orders__download-all">
                 {{ $t('Download all') }}
               </SfButton>
             </SfTableHeader>
@@ -69,6 +69,7 @@
 <script>
 import UserOrder from '@vue-storefront/core/modules/order/components/UserOrdersHistory';
 import { SfTabs, SfTable, SfButton } from '@storefront-ui/vue';
+import { ModalList } from 'theme/store/ui/modals'
 
 export default {
   name: 'OMyAccountOrdersHistory',
@@ -102,6 +103,11 @@ export default {
         })
       })
       return orders
+    }
+  },
+  methods: {
+    downloadAll () {
+      this.$store.dispatch('ui/openModal', { name: ModalList.FeatureNotImplemented })
     }
   }
 }

--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -138,7 +138,7 @@ export default {
   },
   methods: {
     showNewsletterPopup () {
-      this.$store.dispatch('ui/openModal', { name: ModalList.Newsletter })
+      this.$store.dispatch('ui/openModal', { name: ModalList.FeatureNotImplemented })
     }
   },
   watch: {

--- a/store/ui/modals.ts
+++ b/store/ui/modals.ts
@@ -6,7 +6,7 @@ export enum ModalList {
   Auth = 'm-modal-authentication',
   AccountBenefits = 'm-modal-account-benefits',
   TermsAndConditions = 'm-modal-terms-and-conditions',
-  Newsletter = 'm-modal-newsletter'
+  FeatureNotImplemented = 'm-modal-feature-not-implemented'
 }
 
 /**
@@ -17,7 +17,7 @@ export const modalComponents = new Map([
   [ModalList.Auth, () => import(/* webpackChunkName: "vsf-modals" */ 'theme/components/molecules/modals/m-modal-authentication.vue')],
   [ModalList.AccountBenefits, () => import(/* webpackChunkName: "vsf-modals" */ 'theme/components/molecules/modals/m-modal-account-benefits.vue')],
   [ModalList.TermsAndConditions, () => import(/* webpackChunkName: "vsf-modals" */ 'theme/components/molecules/modals/m-modal-terms-and-conditions.vue')],
-  [ModalList.Newsletter, () => import(/* webpackChunkName: "vsf-modals" */ 'theme/components/molecules/modals/m-modal-newsletter.vue')]
+  [ModalList.FeatureNotImplemented, () => import(/* webpackChunkName: "vsf-modals" */ 'theme/components/molecules/modals/m-modal-feature-not-implemented.vue')]
 ])
 
 /**


### PR DESCRIPTION
### Related Issues

Closes #220

### Short Description and Why It's Useful
These changes show notification with information that feature is not implemented when user clicks "Download all" on the orders history page.

### Screenshots of Visual Changes before/after (If There Are Any)
No screenshots

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)