### PR TITLE
#115 Smart link prefetching

### DIFF
--- a/layouts/Default.vue
+++ b/layouts/Default.vue
@@ -70,6 +70,7 @@ export default {
     return {
       loadOrderConfirmation: false,
       ordersData: [],
+      quicklink: null,
       microcartAsyncComponent: () => ({
         component: OMicrocart(),
         loading: LoadingSpinner,
@@ -91,11 +92,18 @@ export default {
       next();
     });
     this.$router.afterEach(() => {
+      if (!isServer) {
+        this.quicklink.listen();
+      }
       this.$Progress.finish();
     });
     this.$bus.$on('offline-order-confirmation', this.onOrderConfirmation);
   },
   mounted () {
+    if (!isServer) {
+      this.quicklink = require('quicklink');
+      this.quicklink.listen();
+    }
     this.$store.dispatch('ui/checkWebpSupport');
   },
   beforeDestroy () {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@storefront-ui/vue": "^0.6.0",
     "body-scroll-lock": "^2.6.4",
+    "quicklink": "^2.0.0-alpha",
     "supports-webp": "^2.0.1",
     "vue": "^2.6.6",
     "vue-lazy-hydration": "^1.0.0-beta.9",

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -565,20 +565,9 @@ export default {
       ]
       : [];
 
-    const link = []
-    this.products.forEach(product => {
-      link.push(
-        {
-          rel: 'prefetch',
-          href: product.link
-        }
-      )
-    })
-
     return {
       title: htmlDecode(meta_title || name),
-      meta,
-      link
+      meta
     };
   }
 };

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -565,9 +565,20 @@ export default {
       ]
       : [];
 
+    const link = []
+    this.products.forEach(product => {
+      link.push(
+        {
+          rel: 'prefetch',
+          href: product.link
+        }
+      )
+    })
+
     return {
       title: htmlDecode(meta_title || name),
-      meta
+      meta,
+      link
     };
   }
 };


### PR DESCRIPTION
### Related Issues
Closes #115

### Short Description and Why It's Useful
These changes add `<link rel="prefetch">` with URLs to products on the category page. This will force the browser to prefetch product pages.

I tested adding links to ES queries to prefetch but it won't work. The problem is because ES query to get product data is sent by the server (not browser), so prefetching it by the browser hasn't sense.

### Screenshots of Visual Changes before/after (If There Are Any)
https://prnt.sc/rl4ilk

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)