### PR TITLE
Mega menu is shown behind search overlay

### DIFF
--- a/components/molecules/m-menu.vue
+++ b/components/molecules/m-menu.vue
@@ -2,7 +2,7 @@
   <div class="m-menu">
     <SfMegaMenu
       :title="title || currentCategoryTitle"
-      :visible="true"
+      :visible="visible"
     >
       <SfMegaMenuColumn
         v-for="category in categories"
@@ -55,6 +55,10 @@ import { checkWebpSupport } from 'theme/helpers'
 export default {
   components: { SfMegaMenu, SfIcon, SfImage },
   props: {
+    visible: {
+      type: Boolean,
+      default: true
+    },
     title: {
       type: String,
       default: ''

--- a/components/organisms/o-header.vue
+++ b/components/organisms/o-header.vue
@@ -2,7 +2,8 @@
   <div class="o-header">
     <SfOverlay
       class="overlay"
-      :visible="isHoveredMenu"
+      :visible="isHoveredMenu || isSearchPanelVisible"
+      @click="$store.commit('ui/setSearchpanel', false)"
     />
     <SfHeader
       :active-icon="activeIcon"
@@ -26,6 +27,7 @@
             {{ category.name }}
           </router-link>
           <MMenu
+            :visible="isHoveredMenu && !isSearchPanelVisible"
             :categories-ids="category.children_data"
             :title="category.name"
           />
@@ -124,9 +126,14 @@ export default {
 <style lang="scss" scoped>
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
-.sf-header-navigation-item:hover .m-menu {
-  opacity: 1;
-  visibility: visible;
+.sf-header-navigation-item {
+  &:hover .m-menu {
+    opacity: 1;
+    visibility: visible;
+  }
+  &::after {
+    bottom: 0;
+  }
 }
 .overlay {
   position:absolute;
@@ -170,18 +177,18 @@ export default {
       visibility: visible;
       top: 0;
       z-index: 1;
+      --mega-menu-aside-menu-height: calc(100vh - var(--bottom-navigation-height) - var(--bar-height));
     }
   }
 }
 .sf-header {
   position: relative;
   z-index: 1;
+  ::v-deep &__sticky-container {
+    max-width: 1240px;
+  }
 }
 .ml-auto {
   margin-left: auto;
-}
-.sf-header-navigation-item:hover ::v-deep .m-menu {
-  opacity: 1;
-  visibility: visible;
 }
 </style>

--- a/components/organisms/o-search-panel.vue
+++ b/components/organisms/o-search-panel.vue
@@ -165,7 +165,12 @@ export default {
   overflow-x: hidden;
 
   @include for-mobile {
-    max-height: calc(100vh - var(--header-container-height));
+    max-height: calc(100vh - var(--header-container-height) - var(--bottom-navigation-height));
+  }
+
+  @include for-desktop {
+    max-width: 1240px;
+    margin: auto;
   }
 
   .container {

--- a/components/organisms/o-search.vue
+++ b/components/organisms/o-search.vue
@@ -10,8 +10,8 @@
     <SfSidebar
       :visible="isSearchPanelVisible"
       :button="false"
+      :overlay="false"
       class="sf-sidebar sidebar__search"
-      @close="$store.commit('ui/setSearchpanel', false)"
     >
       <component
         v-if="search && isSearchPanelVisible"

--- a/layouts/Default.vue
+++ b/layouts/Default.vue
@@ -146,6 +146,8 @@ export default {
 body {
   --overlay-z-index: 1;
   --sidebar-aside-z-index: 2;
+  --bottom-navigation-height: 3.75rem;
+  --bar-height: 3.125rem;
   color: var(--c-text);
   font-size: var(--font-size-regular);
   font-family: var(--body-font-family-secondary);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #263 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes overlapping mega menu with search results - if search is opened then mega menu links are hidden. Also search results were aligned to mega menu overlay width to be consistent.

Search results on mobile view were also fixed (they were cut on the bottom by `o-bottom-navigation` component).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Dektop view

![desktop-view](https://user-images.githubusercontent.com/56868128/77424080-d4db7a00-6dd0-11ea-8cac-151561f5facf.png)

Mobile view

![mobile-view](https://user-images.githubusercontent.com/56868128/77424103-d9a02e00-6dd0-11ea-906f-23d76900d018.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)