### PR TITLE
Make Capybara compatible with VSF v1.12

### DIFF
--- a/components/organisms/o-my-account-order-details.vue
+++ b/components/organisms/o-my-account-order-details.vue
@@ -155,7 +155,7 @@
 </template>
 
 <script>
-import SearchQuery from '@vue-storefront/core/lib/search/searchQuery';
+import { SearchQuery } from 'storefront-query-builder';
 import { getThumbnailPath, productThumbnailPath } from '@vue-storefront/core/helpers'
 import {
   SfHeading,

--- a/local.json
+++ b/local.json
@@ -1,5 +1,8 @@
 {
   "theme": "@vue-storefront/theme-capybara",
+  "server": {
+    "api": "api-search-query"
+  },
   "products": {
     "thumbnails": {
       "width": 324,
@@ -15,6 +18,12 @@
   "entities": {
     "category": {
       "categoriesDynamicPrefetch": false
+    },
+    "attribute": {
+      "loadByAttributeMetadata": true
     }
+  },
+  "urlModule": {
+    "enableMapFallbackUrl": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@storefront-ui/vue": "^0.6.0",
     "body-scroll-lock": "^2.6.4",
     "quicklink": "^2.0.0-alpha",
+    "storefront-query-builder": "^0.0.9",
     "supports-webp": "^2.0.1",
     "vue": "^2.6.6",
     "vue-lazy-hydration": "^1.0.0-beta.9",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #112 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR is needed to make Capybara theme compatible with VSF v1.12. It uses the latest improvements added in VSF and they are enabled in `local.json` file.

This PR can be merged when:
- https://github.com/DivanteLtd/vue-storefront/pull/4212 is merged
- there is a VSF API v1.12 instance available and can be used by Capybara test site on https://capybara.storefrontcloud.io/

So after merging this PR please do the following on test site https://capybara.storefrontcloud.io/:
- merge `local.json` from this PR with the one on test site
- add VSF API v1.12 URL to `api.url` configuration in `local.json` on test site.
- update VSF branch to `develop` or v1.12 (if it will be available at that time) on test site.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)