### PR TITLE
Order history does not work if shipping info is missing

### DIFF
--- a/components/organisms/o-my-account-order-details.vue
+++ b/components/organisms/o-my-account-order-details.vue
@@ -88,7 +88,7 @@
       </div>
     </div>
     <div class="order-details__informations">
-      <div>
+      <div v-if="shippingAddress">
         <SfHeading
           :title="$t('Shipping address')"
           class="sf-heading--left sf-heading--no-underline"
@@ -106,7 +106,7 @@
           <p>{{ shippingAddress.country }}</p>
         </address>
       </div>
-      <div>
+      <div v-if="order.shipping_description">
         <SfHeading
           :title="$t('Shipping method')"
           class="sf-heading--left sf-heading--no-underline"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #285 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes Order history view when shipping information is not available in current ordered item.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot_2020-04-01 My Account - Vue Storefront](https://user-images.githubusercontent.com/56868128/78126713-3a53ea00-7413-11ea-9ac6-5105245b9b31.png)

![Screenshot_2020-04-01 My Account - Vue Storefront(1)](https://user-images.githubusercontent.com/56868128/78126796-5b1c3f80-7413-11ea-80e4-36788a288ca9.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)