### PR TITLE
Add class to place the order button

### DIFF
--- a/components/organisms/o-confirm-order.vue
+++ b/components/organisms/o-confirm-order.vue
@@ -171,7 +171,7 @@
       </div>
       <div class="summary__group">
         <SfButton
-          class="sf-button--full-width summary__action-button"
+          class="place-order-btn sf-button--full-width summary__action-button"
           :disabled="$v.orderReview.$invalid || !productsInCart.length"
           @click="placeOrder"
         >


### PR DESCRIPTION
### Related Issues
No related issues

### Short Description and Why It's Useful
This class is used by third-party extensions to detect "Place the order" button. For example, Braintree Payment extension uses it (https://github.com/danrcoull/vsf-payment-braintree)

### Screenshots of Visual Changes before/after (If There Are Any)
No screenshots

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)