### PR TITLE
Create separate GraphQL chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,12 @@ module.exports = function (config, { isClient }) {
             name: 'sfui',
             priority: 2
           },
+          graphQl: {
+            // create 'vsf-graphql' group from GraphQL-related modules to decrease vendor-initial and/or vendor-async sizes
+            test: /graphql|apollo/,
+            name: 'vsf-graphql',
+            priority: 2
+          },
           vendorInitial: {
             // create 'vendor' group from initial packages from node_modules except Storefront UI
             test: /node_modules/,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #104 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR extracts GraphQL-related modules to separate chunk to decrease `vendor-async` size.

Results are promising:
- before this change total load size on Homepage was 1502872 B
- after this change total load size on Homepage is 1318239 B
- load size reduction is **~12,3%**  🎉 

The only one disadvantage is that suddenly there are 2 `vsf-search-adapter-0` and `vsf-search-adapter-1` chunks despite the rule in our webpack configuration to always join them together  🤔
This is strange but I think that benefits from this PR are more important. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

#### Before ####
![before-total](https://user-images.githubusercontent.com/56868128/78781502-a77df700-79a0-11ea-8db5-d918f00f6b1a.png)

![before](https://user-images.githubusercontent.com/56868128/78781505-abaa1480-79a0-11ea-8ffc-2bad5c8d33c9.png)


#### After ####

![after-total](https://user-images.githubusercontent.com/56868128/78781512-aea50500-79a0-11ea-8b5d-1a02674b906c.png)


![after](https://user-images.githubusercontent.com/56868128/78781515-b1075f00-79a0-11ea-8e20-f0f1c5132982.png)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)