### PR TITLE
Revert: Separate GraphQL chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,12 +59,6 @@ module.exports = function (config, { isClient }) {
             name: 'sfui',
             priority: 2
           },
-          graphQl: {
-            // create 'vsf-graphql' group from GraphQL-related modules to decrease vendor-initial and/or vendor-async sizes
-            test: /graphql|apollo/,
-            name: 'vsf-graphql',
-            priority: 2
-          },
           vendorInitial: {
             // create 'vendor' group from initial packages from node_modules except Storefront UI
             test: /node_modules/,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #104 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR reverts recent webpack change that created separate GraphQL chunk. It worked as expected on v1.11.x but it stopped on v1.12, where the `vsf-graphql` chunk is always fetched on Homepage so this improvement does not make sense anymore. It looks like this is a bigger issue here so it is better to just revert previous PR now and investigate this problem.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)