### PR TITLE
Adapting notifications to Storefront UI v0.7.x

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -32,6 +32,7 @@ body {
   --sidebar-aside-z-index: 2;
   --bottom-navigation-height: 3.75rem;
   --bar-height: 3.125rem;
+  --notification-font-size: var(--font-sm);
   color: var(--c-text);
   font-size: var(--font-size-regular);
   font-family: var(--font-family-secondary);

--- a/components/organisms/o-notification.vue
+++ b/components/organisms/o-notification.vue
@@ -6,8 +6,7 @@
       class="notification"
       :visible="true"
       :type="getType(notification)"
-      :message="notification.message"
-      @click:close="removeNotification(notification.id)"
+      :message="notification.message | htmlDecode"
     >
       <template #action>
         <button
@@ -19,18 +18,26 @@
           {{ action.label }}
         </button>
       </template>
+      <template #close>
+        <SfIcon
+          class="sf-notification__close"
+          icon="cross"
+          color="white"
+          @click="removeNotification(notification.id)"
+        />
+      </template>
     </SfNotification>
   </div>
 </template>
 
 <script>
 import { Notification } from '@vue-storefront/core/modules/notification/components/Notification';
-import { SfNotification } from '@storefront-ui/vue';
+import { SfNotification, SfIcon } from '@storefront-ui/vue';
 
 export default {
   name: 'ONotification',
   mixins: [Notification],
-  components: { SfNotification },
+  components: { SfNotification, SfIcon },
   methods: {
     getType ({ type }) {
       return ['secondary', 'info', 'success', 'warning', 'danger'].includes(type) ? type : 'danger';
@@ -74,18 +81,16 @@ export default {
     margin-top: 1rem;
   }
   .sf-notification__action {
-    margin-left: 1.25rem;
     cursor: pointer;
-    &:last-child {
-      margin-right: 2.25rem;
-    }
+    margin: 0.3rem 1rem 0 0;
   }
-}
-@include for-desktop {
-  .sf-notification {
-    max-width: none;
-    width: max-content;
+  @include for-desktop {
+    max-width: 32rem;
     align-self: end;
+    .sf-notification__close {
+      position: relative;
+      margin-left: var(--spacer-lg);
+    }
   }
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #303 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes layout for notifications because it has been corrupted after integrating Storefront UI v0.7.x.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

#### Desktop view ####
![desktop](https://user-images.githubusercontent.com/56868128/79543557-fa853780-808d-11ea-92c1-6cb42ffa537d.png)

#### Mobile view ####
![mobile](https://user-images.githubusercontent.com/56868128/79543568-fe18be80-808d-11ea-972d-b8fb91308aac.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)