### PR TITLE
Limit max size of image in order history

### DIFF
--- a/components/organisms/o-my-account-order-details.vue
+++ b/components/organisms/o-my-account-order-details.vue
@@ -22,7 +22,7 @@
       </template>
     </SfHeading>
     <div class="order-details__products">
-      <SfTable class="sf-table--bordered">
+      <SfTable class="sf-table--bordered table">
         <SfTableHeading>
           <SfTableHeader>{{ $t('Thumbnail') }}</SfTableHeader>
           <SfTableHeader class="sf-table__header--center">
@@ -39,8 +39,8 @@
           </SfTableHeader>
         </SfTableHeading>
         <SfTableRow v-for="product in products" :key="product.id">
-          <SfTableData>
-            <img :src="getThumbnailForProduct(product)" :alt="product.name | htmlDecode">
+          <SfTableData class="table__image">
+            <SfImage :src="getThumbnailForProduct(product)" :alt="product.name | htmlDecode" />
           </SfTableData>
           <SfTableData class="sf-table__header--center">
             {{ product.name | htmlDecode }}
@@ -162,7 +162,8 @@ import {
   SfArrow,
   SfBadge,
   SfTable,
-  SfProperty
+  SfProperty,
+  SfImage
 } from '@storefront-ui/vue';
 
 export default {
@@ -172,7 +173,8 @@ export default {
     SfArrow,
     SfBadge,
     SfTable,
-    SfProperty
+    SfProperty,
+    SfImage
   },
   props: {
     order: {
@@ -287,9 +289,6 @@ export default {
     color: var(--c-text);
   }
 }
-</style>
-
-<style lang="scss">
 .order-details__summary {
   .sf-property__name {
     min-width: 100px;
@@ -297,6 +296,12 @@ export default {
   .sf-property__value {
     min-width: 180px;
     text-align: center;
+  }
+}
+.table {
+  --_table-column-width: 5;
+  &__image {
+    --image-width: 5rem;
   }
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #312 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes images in order history that might be to big if image proxy is disabled or not configured.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Adnotacja 2020-04-17 131708](https://user-images.githubusercontent.com/56868128/79563997-231d2980-80ae-11ea-8ec9-9cff70646ec4.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)