### PR TITLE
Unnecessary 'more actions' icon in cart in mobile view

### DIFF
--- a/components/organisms/o-microcart-panel.vue
+++ b/components/organisms/o-microcart-panel.vue
@@ -42,6 +42,9 @@
                   </SfProperty>
                 </div>
               </template>
+              <template #more-actions>
+                <span />
+              </template>
             </SfCollectedProduct>
           </transition-group>
         </div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #337 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removes 'more actions' icon in cart in mobile view because it is not used.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![zrzut 2020-04-23 08 47 55](https://user-images.githubusercontent.com/56868128/80068238-8d671b80-853f-11ea-9438-57a321d36458.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)