### PR TITLE
'Empty cart' icon is not displayed

### DIFF
--- a/components/organisms/o-microcart-panel.vue
+++ b/components/organisms/o-microcart-panel.vue
@@ -49,7 +49,7 @@
       <div v-else key="empty-cart" class="empty-cart">
         <div class="empty-cart__banner">
           <SfImage
-            src="@storefront-ui/shared/icons/empty_cart.svg"
+            :src="require('@storefront-ui/shared/icons/empty_cart.svg')"
             :alt="$t('Your bag is empty')"
             class="empty-cart__image"
           />


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #335 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This fixes 'empty cart' icon, which was not displayed in cart sidebar.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![zrzut 2020-04-23 09 41 43](https://user-images.githubusercontent.com/56868128/80072689-e2f2f680-8546-11ea-8995-67174a307406.png)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)