### PR TITLE
Disable quicklink by default

### DIFF
--- a/local.json
+++ b/local.json
@@ -27,6 +27,6 @@
     "enableMapFallbackUrl": true
   },
   "quicklink": {
-    "enabled": true
+    "enabled": false
   }
 }


### PR DESCRIPTION
### Related Issues

Related #343

### Short Description and Why It's Useful
Quicklink causes infinite resource loading. We need to disable it by default until we find good solution.

### Screenshots of Visual Changes before/after (If There Are Any)
No screenshots

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)