### PR TITLE
Size guide is not visible when user switches to PDP from related list

### DIFF
--- a/components/molecules/m-product-options-configurable.vue
+++ b/components/molecules/m-product-options-configurable.vue
@@ -6,8 +6,9 @@
       :message="product.errors | formatProductMessages"
       type="danger"
     />
-    <div v-for="attribute in productAttributes" :key="attribute.id">
+    <template v-for="attribute in productAttributes">
       <SfSelect
+        :key="attribute.id"
         v-if="attribute.attribute_code !== 'color'"
         :label="getAttributeLabel(attribute)"
         :value="getActiveOption(attribute)"
@@ -22,9 +23,7 @@
           <SfProductOption :label="attributeOption.label" />
         </SfSelectOption>
       </SfSelect>
-    </div>
-    <div v-for="attribute in productAttributes" :key="attribute.id">
-      <div v-if="attribute.attribute_code === 'color'" class="product__colors desktop-only">
+      <div v-else :key="attribute.id" class="product__colors">
         <p class="product__color-label">
           {{ attribute.label }}:
         </p>
@@ -33,11 +32,11 @@
           :key="attributeOption.id"
           :color="getColorValue(attributeOption)"
           class="product__color"
-          :selected="parseInt(configuration.color.id) === parseInt(attributeOption.id)"
+          :selected="isColorSelected(attributeOption)"
           @click="handleChangeOption(attributeOption)"
         />
       </div>
-    </div>
+    </template>
   </div>
 </template>
 <script>
@@ -93,6 +92,9 @@ export default {
       return (option) => option.type === 'color'
         ? get(config.products.colorMappings, option.label, option.label)
         : undefined
+    },
+    isColorSelected () {
+      return attributeOption => this.configuration.color && parseInt(this.configuration.color.id) === parseInt(attributeOption.id);
     }
   },
   methods: {
@@ -107,11 +109,12 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
-@import "~@storefront-ui/shared/styles/helpers/typography";
 
 .m-product-options-configurable {
   border-bottom: 1px solid #f1f2f3;
   padding-bottom: 10px;
+  display: flex;
+  flex-wrap: wrap;
   @include for-desktop {
     border: 0;
     padding-bottom: 0;
@@ -123,22 +126,21 @@ export default {
 
 .product {
   &__select-size {
+    flex: 100%;
     margin: 0 var(--spacer-sm);
     @include for-desktop {
       margin: 0;
     }
   }
   &__colors {
-    @include font(
-      --product-color-font,
-      var(--font-normal),
-      var(--font-lg),
-      1.6,
-      var(--font-family-secondary)
-    );
     display: flex;
+    flex: 100%;
+    order: 1;
     align-items: center;
-    margin-top: var(--spacer-xl);
+    margin: var(--spacer-xl) var(--spacer-sm) 0;
+    @include for-desktop {
+      margin: var(--spacer-xl) 0 0;
+    }
   }
   &__color-label {
     margin: 0 var(--spacer-lg) 0 0;

--- a/components/molecules/m-product-short-info.vue
+++ b/components/molecules/m-product-short-info.vue
@@ -110,4 +110,16 @@ export default {
     );
   }
 }
+
+@keyframes moveicon {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, 30%, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
 </style>

--- a/components/organisms/o-product-details.vue
+++ b/components/organisms/o-product-details.vue
@@ -16,7 +16,7 @@
         :reviews="reviews"
       />
       <SfButton
-        v-if="sizeOption"
+        v-show="sizeOption"
         @click.native="openSizeGuide"
         class="sf-button--text desktop-only product__guide"
       >
@@ -163,7 +163,6 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
-@import "~@storefront-ui/shared/styles/helpers/typography";
 
 .product {
   @include for-desktop {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #329 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes some runtime errors we had on PDP page, like duplicated keys in `v-for` directive. It also enables color selector on mobile view. Size guide should be now visible in all cases.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
#### Mobile view ####
![mobile](https://user-images.githubusercontent.com/56868128/80966498-e9ba1d00-8e14-11ea-99e8-86c0cc8a5aa7.png)

---

#### Desktop view ####
![desktop](https://user-images.githubusercontent.com/56868128/80966500-eaeb4a00-8e14-11ea-9917-adaad6ba1af5.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)