### PR TITLE
Problem with displaying dropdown list

### DIFF
--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -686,7 +686,7 @@ export default {
   }
 }
 .sort-by {
-  --select-dropdown-z-index: 1;
+  --select-dropdown-z-index: 2;
   flex: unset;
   ::v-deep {
     .sf-select__dropdown {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #328 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR fixes overlapping issue with dropdown list and `SfProductCard` hover styles -- see screenshot below: dropdown list is rendered on top of hovered `SfProductCard`.
Second issue regarding not properly positioned arrow inside drodown list has been fixed in Storefront UI in v0.7.2.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![desktop](https://user-images.githubusercontent.com/56868128/81047211-415e9400-8eba-11ea-869a-ca6cc713e2c1.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)