### PR TITLE
Tabs on the product page are not reset properly

### DIFF
--- a/components/molecules/m-product-additional-info.vue
+++ b/components/molecules/m-product-additional-info.vue
@@ -2,8 +2,7 @@
   <SfTabs
     class="m-product-additional-info product__tabs"
     :open-tab="openTab"
-    :key="openTab"
-    @toggle="onTabChange"
+    :key="product.id"
   >
     <SfTab :title="$t('Description')">
       <div itemprop="description" v-html="product.description" />
@@ -55,16 +54,8 @@ export default {
       return this.reviews.length
     }
   },
-  methods: {
-    onTabChange (index) {
-      let counter = 0
-      this.$children[0].$children.forEach(tab => {
-        counter++
-        if (tab._uid === index) {
-          this.$store.commit('ui/setActiveProductTab', counter);
-        }
-      })
-    }
+  destroyed () {
+    this.$store.commit('ui/setActiveProductTab', 1);
   }
 };
 </script>

--- a/components/molecules/m-product-additional-info.vue
+++ b/components/molecules/m-product-additional-info.vue
@@ -54,7 +54,7 @@ export default {
       return this.reviews.length
     }
   },
-  destroyed () {
+  beforeDestroy () {
     this.$store.commit('ui/setActiveProductTab', 1);
   }
 };


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #228 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
After opening product page always first tab with description will be shown.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
No visual changes.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)