### PR TITLE
Support discount coupons in mobile view

### DIFF
--- a/components/molecules/m-price-summary.vue
+++ b/components/molecules/m-price-summary.vue
@@ -32,7 +32,6 @@
         :class="{'sf-property--large': isLarge}"
       />
       <SfButton
-        v-if="allowPromoCodeRemoval"
         class="sf-button sf-button--outline promo-code__button"
         @click="removeCoupon"
       >
@@ -61,10 +60,6 @@ export default {
   },
   props: {
     isLarge: {
-      type: Boolean,
-      default: false
-    },
-    allowPromoCodeRemoval: {
       type: Boolean,
       default: false
     }

--- a/components/organisms/o-confirm-order.vue
+++ b/components/organisms/o-confirm-order.vue
@@ -223,6 +223,7 @@
         </SfCheckbox>
       </div>
     </div>
+    <APromoCode class="mobile-only" :allow-promo-code-removal="false" />
     <div class="characteristics mobile-only">
       <SfCharacteristic
         v-for="characteristic in characteristics"
@@ -253,7 +254,7 @@
         </SfCheckbox>
         <APromoCode :allow-promo-code-removal="false" />
       </div>
-      <MPriceSummary class="totals__element" :allow-promo-code-removal="true" />
+      <MPriceSummary class="totals__element" />
     </div>
     <div class="actions">
       <SfButton
@@ -407,7 +408,7 @@ export default {
       });
     },
     openTermsAndConditionsModal () {
-      this.openModal({name: ModalList.TermsAndConditions})
+      this.openModal({ name: ModalList.TermsAndConditions })
     }
   },
   mounted () {
@@ -592,5 +593,11 @@ a {
 }
 .no-flex {
   flex: unset;
+}
+.promo-code {
+  &.mobile-only {
+    max-width: 100%;
+    width: 20rem;
+  }
 }
 </style>

--- a/components/organisms/o-order-summary.vue
+++ b/components/organisms/o-order-summary.vue
@@ -5,7 +5,7 @@
       :level="3"
       class="sf-heading--left sf-heading--no-underline title"
     />
-    <MPriceSummary :is-large="true" :allow-promo-code-removal="true" />
+    <MPriceSummary :is-large="true" />
     <APromoCode :allow-promo-code-removal="false" />
     <div class="characteristics">
       <SfCharacteristic


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #361

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR adds possibility to add and remove discount coupon on mobile view. This is possible in the last step in the checkout.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![1](https://user-images.githubusercontent.com/56868128/81683570-8a808c00-9456-11ea-8259-eb4c45bb1a2e.png)
![2](https://user-images.githubusercontent.com/56868128/81683576-8bb1b900-9456-11ea-8901-2c1d48567c15.png)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)