### PR TITLE
update typing for price helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed / Improved
 
 - Support theme configuration via CLI (#369)
+- Update types for `getBundleOptionsValues` (#371)
 
 ## [1.0.0-rc.2] - 2020-05-13
 

--- a/helpers/price.ts
+++ b/helpers/price.ts
@@ -7,7 +7,7 @@ function calculateBundleOptionsPrice (product) {
   const allBundleOptions = product.bundle_options || []
   const selectedBundleOptions = Object.values(get(product, 'product_option.extension_attributes.bundle_options', {}))
   const price = getBundleOptionPrice(
-    getBundleOptionsValues(selectedBundleOptions, allBundleOptions)
+    getBundleOptionsValues(selectedBundleOptions as any[], allBundleOptions)
   )
 
   return price.priceInclTax


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In 1.12 there will be updated typing for `getBundleOptionsValues` and as ` const selectedBundleOptions = Object.values(get(product, 'product_option.extension_attributes.bundle_options', {}))` returns `uknown[]` it will fail in 1.12. I can't add new type (because it not exist in 1.11), so I've added `any[]`.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)