### PR TITLE
update sfui to 0.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - UNRELEASED
+
+### Added
+### Changed / Improved
+
+- Update sfui version to 0.7.11
+
 ## [1.0.1] - 2020.06.02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@storefront-ui/vue": "0.7.10",
+    "@storefront-ui/vue": "0.7.11",
+    "@storefront-ui/shared": "0.7.11",
     "body-scroll-lock": "^3.0.1",
     "quicklink": "^2.0.0-alpha",
     "storefront-query-builder": "https://github.com/DivanteLtd/storefront-query-builder.git",


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In sfui to version [0.7.11](https://github.com/DivanteLtd/storefront-ui/commit/d699b3a3c56c7fe13a55b970d873e2333b18c358#diff-099a765d0e8e27c90657641e46433003L33) there was a dash in version number and right now we use components in version 0.7.10 and styles in newest version 0.7.17. Which result in some bugs. So with this change we will have both components and styles from sfui in version 0.7.11. It should be better starting point for making update to newest sfui version.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
before: 
![Zrzut ekranu z 2020-06-30 11-54-33](https://user-images.githubusercontent.com/42383376/86112599-7bb66d00-bac8-11ea-9d79-60a64bf834a6.png)

after:
![Zrzut ekranu z 2020-06-30 11-46-03](https://user-images.githubusercontent.com/42383376/86112142-e4e9b080-bac7-11ea-865c-9c075678943a.png)



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)