### PR TITLE
Fixed: Error page on mobile and desktop (#398-Adjust-error-page)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed / Improved
 
 - Update sfui version to 0.7.11
+- Adjusted the error page (#398)
 
 ## [1.0.1] - 2020.06.02
 

--- a/components/molecules/m-error.vue
+++ b/components/molecules/m-error.vue
@@ -51,7 +51,7 @@ export default {
   padding: 0 1.25rem;
   &__image,
   &__message {
-    margin: calc(var(--spacer-2xl) * 3) 0;
+    margin: calc(var(--spacer-xl) * 2) 0;
     text-align: center;
     --heading-border: none;
   }


### PR DESCRIPTION
Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #398 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Error page was of too much height, due to which "Back" and "Returned to Home" were not visible without scrolling.
Found that margin on error image was high, adjusted the margin for .error class from '2xl * 3' to 'xl * 2' .


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before Mobile :
![CapybaraErrorMobileBefore](https://user-images.githubusercontent.com/8766155/86436327-ae0dd780-bd1f-11ea-95a4-b552a7e054ca.png)

Before Desktop:
![CapybaraErrorBefore](https://user-images.githubusercontent.com/8766155/86436364-bebe4d80-bd1f-11ea-96a3-1afa18c60a68.png)

After Mobile:
![CapybaraerrorMobileAfter](https://user-images.githubusercontent.com/8766155/86436392-cc73d300-bd1f-11ea-83eb-7d2e773efc50.png)

After Desktop:
![CapybaraErrorAfter](https://user-images.githubusercontent.com/8766155/86436435-e01f3980-bd1f-11ea-9b86-93a075af44f8.png)



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)