### PR TITLE
Used sku instead of product_id while preparing order line items product detail

### DIFF
--- a/components/organisms/o-my-account-order-details.vue
+++ b/components/organisms/o-my-account-order-details.vue
@@ -195,7 +195,7 @@ export default {
       searchQuery = searchQuery.applyFilter({ key: 'configurable_children.sku', value: { 'in': arrayOfSKUs } })
       this.$store.dispatch('product/list', { query: searchQuery, start: 0, size: this.order.items.length, updateState: false }, { root: true }).then((resp) => {
         resp.items.forEach(responseItem => {
-          let relatedProduct = this.order.items.find(item => { return item.product_id === responseItem.id })
+          let relatedProduct = this.order.items.find(item => { return item.sku === responseItem.sku })
           this.products.push(Object.assign({}, relatedProduct, responseItem))
         })
       })


### PR DESCRIPTION
Used sku instead of product_id while preparing order line items product

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #415

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
While preparing order item product detail we are using sku to fetch product detail, but at the time of preparing item product detail we are comparing using product_id. 

This may cause issue when we are using different systems,
 also to make code consistent it should use sku while comparison as well. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)