### PR TITLE
 Improved: Size of Products in bestsellers section (#382-bestseller-products-size)

### DIFF
--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -174,8 +174,6 @@ export default {
   }
 }
 .section {
-  padding-left: var(--spacer-xl);
-  padding-right: var(--spacer-xl);
   @include for-desktop {
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
Removed the CSS properties which were forcing some section with class 'section' (Bestseller section and share your look section) on home page, to have padding on mobile view, which cause less space for them to occupy. 
Also these properties were making these section shrink and not in align with other sections of home page.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#382 

Closes #382 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As mentioned in the issue, size of bestseller carousel was smaller in comparison to other carousels.
On debugging, I found that .section class have padding on mobile devices, this class was added on #shareyourlook and #bestseller section, and causing them to shrink more in the mobile devices. 
Due to which size of bestseller carousel was smaller in comparison to other carousels.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before 
![Before#382](https://user-images.githubusercontent.com/8766155/87276261-9a235c00-c4fd-11ea-9942-e1c1c67ca2b5.png)
After
![After#382](https://user-images.githubusercontent.com/8766155/87276284-a3142d80-c4fd-11ea-806c-a8e42b94fa7f.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)