### PR TITLE
393: Use short description in PDP top section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed / Improved
 
 - Adjusted the error page (#398)
+- Use short description in PDP top section (#393)
 
 ## [1.0.2] - 03.07.2020
 

--- a/components/molecules/m-product-short-info.vue
+++ b/components/molecules/m-product-short-info.vue
@@ -26,7 +26,10 @@
         {{ $t("Read all {count} review", { count: reviewsCount }) }}
       </AProductRating>
     </div>
-    <div class="product__description desktop-only" v-html="product.description" />
+    <div
+      class="product__description desktop-only"
+      v-html="product.short_description || product.description"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #393

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In PDP top section `product.short_description` is used (if available), or `product.description`.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![393](https://user-images.githubusercontent.com/56868128/87548239-823e0a80-c6ac-11ea-86f4-229df6fef34b.png)


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)