### PR TITLE
#436 Fixed selected size option on product page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use short description in PDP top section (#393)
 - Fixed `isAddToCartDisabled` computed property (#377)
 - Update filters bar on category page (#381)
+- Corrected displayed the selected size option on product page (#436)
 
 ## [1.0.2] - 03.07.2020
 

--- a/components/molecules/m-product-options-configurable.vue
+++ b/components/molecules/m-product-options-configurable.vue
@@ -40,8 +40,9 @@
   </div>
 </template>
 <script>
-import get from 'lodash-es/get'
 import config from 'config'
+import { mapGetters } from 'vuex';
+import get from 'lodash-es/get'
 import { SfAlert, SfSelect, SfProductOption, SfColor } from '@storefront-ui/vue';
 import { getAvailableFiltersByProduct } from '@vue-storefront/core/modules/catalog/helpers/filters'
 export default {
@@ -66,13 +67,18 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      getCurrentProductOptions: 'product/getCurrentProductOptions'
+    }),
     getActiveOption () {
       return (attribute) => get(this.configuration, `${attribute.attribute_code}.id`, attribute.id)
     },
     getAttributeLabel () {
       return (attribute) => {
         const configName = attribute.attribute_code ? attribute.attribute_code : attribute.label.toLowerCase()
-        return this.configuration[configName] ? this.configuration[configName].label : configName
+        const optionId = this.configuration[configName] ? this.configuration[configName].id : ''
+        const option = this.getCurrentProductOptions[configName].find(o => o.id === optionId)
+        return option.hasOwnProperty('label') ? option.label : ''
       }
     },
     productAttributes () {


### PR DESCRIPTION
### Related Issues
#436 

Closes #436 

### Short Description and Why It's Useful
Fixed the getAttributeLabel computed property for configurable options.


### Screenshots of Visual Changes before/after (If There Are Any)
Before:
<img width="1328" alt="Снимок экрана 2020-08-06 в 20 47 29" src="https://user-images.githubusercontent.com/414067/89618129-98e71400-d89c-11ea-87a1-251db63f7114.png">

After:
<img width="1377" alt="Снимок экрана 2020-08-06 в 20 48 55" src="https://user-images.githubusercontent.com/414067/89618261-cfbd2a00-d89c-11ea-87eb-59339bba7403.png">



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)