### PR TITLE
#438 used i18n for login title.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use short description in PDP top section (#393)
 - Fixed `isAddToCartDisabled` computed property (#377)
 - Update filters bar on category page (#381)
+- Use i18n wrapper for the login title (#438)
 
 ## [1.0.2] - 03.07.2020
 

--- a/components/molecules/m-login.vue
+++ b/components/molecules/m-login.vue
@@ -39,7 +39,7 @@
     </SfButton>
     <div class="aside">
       <SfHeading
-        title="Don't have an account yet?"
+        :title="$t('Don\'t have an account yet?')"
         :level="3"
         class="aside__heading"
       />


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #438 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now I can use i18n dictionaries for translate title in the login modal window

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)