### PR TITLE
Improved: carousel time in product carousel (#444)

### DIFF
--- a/components/molecules/m-product-carousel.vue
+++ b/components/molecules/m-product-carousel.vue
@@ -2,8 +2,8 @@
   <SfCarousel
     class="m-product-carousel"
     :settings="{
-      animationDuration: 3000,
-      rewindDuration: 3000
+      animationDuration: 2000,
+      rewindDuration: 2000
     }"
   >
     <SfCarouselItem v-for="(product, i) in carouselProducts" :key="i">


### PR DESCRIPTION
On mobile devices if you swipe the carousals, it takes time to get stationary.
Experience should be smooth while swiping the carousal
Reduced the, animationDuration and rewindDuration to 2000 from 3000

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #444 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)