### PR TITLE
Improved: Styling around color selector on filters in category page (#443)

### DIFF
--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -786,6 +786,7 @@ export default {
   }
   &__color {
     margin: var(--spacer-xs) var(--spacer-xs) var(--spacer-xs) 0;
+    border: 1px solid var(--c-light);
   }
   &__item {
     --filter-label-color: var(--c-secondary-variant);


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #443 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

White color is not visible due to white background in color filters.
Added border for that


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![colorbefore](https://user-images.githubusercontent.com/8766155/90956219-15cfdb80-e4a2-11ea-8834-5d0e0359f117.png)

After 
![colorafter](https://user-images.githubusercontent.com/8766155/90956218-15374500-e4a2-11ea-8f79-af0481006da7.png)



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)