### PR TITLE
Fixed: Broken tiles of mega menu  (#465-Mega-Menu-Tiles-Mobile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.3] - UNRELEASED
+## [1.0.4] - UNRELEASED
+
+### Added
+
+### Changed / Improved
+
+## [1.0.3] - 20.09.2020
 
 ### Added
 ### Changed / Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed / Improved
+- Fixed Broken tiles of mega menu on mobile (#465)
 
 ## [1.0.3] - 20.09.2020
 

--- a/components/molecules/m-menu.vue
+++ b/components/molecules/m-menu.vue
@@ -121,13 +121,13 @@ export default {
 }
 .aside-menu {
   display: flex;
-  justify-content: space-between;
+  justify-content: stretch;
+  flex-wrap: wrap;
 }
 .aside-banner {
-  margin: 0 1rem;
+  margin-bottom: var(--spacer-sm);
   text-transform: uppercase;
   --banner-height: 300px;
-  --banner-width: 300px;
   &--mobile {
     display: none;
     @include for-mobile {
@@ -135,6 +135,7 @@ export default {
     }
   }
   &--desktop {
+    --banner-width: 300px;
     display: none;
     @include for-desktop {
       display: block;

--- a/components/molecules/m-menu.vue
+++ b/components/molecules/m-menu.vue
@@ -140,6 +140,7 @@ export default {
   &--desktop {
     --banner-width: 300px;
     display: none;
+    margin: 0 var(--spacer-sm);
     @include for-desktop {
       display: block;
     }

--- a/components/molecules/m-menu.vue
+++ b/components/molecules/m-menu.vue
@@ -123,6 +123,9 @@ export default {
   display: flex;
   justify-content: stretch;
   flex-wrap: wrap;
+  @include for-desktop {
+     justify-content: space-between;
+  }
 }
 .aside-banner {
   margin-bottom: var(--spacer-sm);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/theme-capybara",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "New theme for Vue Storefront based on Storefront UI",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Improved the use of flex wrap, justify content and margins to give proper spacing on mobile view.


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #465 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Tiles will be visible properly on mobile view.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before

![before](https://user-images.githubusercontent.com/8766155/93615570-33388c80-f9f1-11ea-89ab-e1a38feab89b.png)


After


![after](https://user-images.githubusercontent.com/8766155/93615577-35025000-f9f1-11ea-8860-446ea41e1ca4.png)



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)