### PR TITLE
Removed: Overridden logo height(#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 
+- Removed: Overridden logo height (#490)
+
 ## [1.0.3] - 20.09.2020
 
 ### Added

--- a/components/atoms/a-logo.vue
+++ b/components/atoms/a-logo.vue
@@ -32,9 +32,5 @@ export default {
 <style lang="scss" scoped>
 .a-logo {
   display: inline-flex;
-  ::v-deep .sf-header__logo {
-    --header-logo-width: 41px;
-    --header-logo-height: 41px;
-  }
 }
 </style>


### PR DESCRIPTION
Removed overridden Height of logo in a-logo

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #490 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

Height of logo in a-logo is forcefully overridden, SFUI default height works perfectly


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before

![before](https://user-images.githubusercontent.com/8766155/93608885-c91be980-f9e8-11ea-8fa1-87cf10db53a4.png)


After

![after](https://user-images.githubusercontent.com/8766155/93608888-c9b48000-f9e8-11ea-845d-5b4a1c3c8cc5.png)



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)