### PR TITLE
Fix src path for added submodule in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To be able to use new Capybara theme in your Vue Storefront installation, you ne
    ```
    node src/themes/capybara/scripts/generate-local-config.js
    ```
-1. Update Vue Storefront configuration by copying `local.json` file from `vsf-capybara` to root `config` directory.
+1. Update Vue Storefront configuration by copying `local.json` file from `src/themes/capybara` to root `config` directory.
 1. Update TypeScript compiler option in `tsconfig.json` in root directory: change value for `compilerOptions`**.**`paths`**.**`theme/*` from default theme `["src/themes/default/*"]` to brand new Capybara theme: `["src/themes/capybara/*"]`.
 1. Download all dependencies and start development server:
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To be able to use new Capybara theme in your Vue Storefront installation, you ne
    ```
 1. Generate `local.json` file from script `generate-local-config.js`:
    ```
-   node src/themes/vsf-capybara/scripts/generate-local-config.js
+   node src/themes/capybara/scripts/generate-local-config.js
    ```
 1. Update Vue Storefront configuration by copying `local.json` file from `vsf-capybara` to root `config` directory.
 1. Update TypeScript compiler option in `tsconfig.json` in root directory: change value for `compilerOptions`**.**`paths`**.**`theme/*` from default theme `["src/themes/default/*"]` to brand new Capybara theme: `["src/themes/capybara/*"]`.


### PR DESCRIPTION
Fixes path for `generate-local-config.js` to be exact to capybara's submodule path example.