### PR TITLE
Corrected displayed the ratings stars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed console warning related to  value of key 'Sort by' is not a string (#476)
 - Update pwacompat to avoid loading multiple favicons (https://github.com/DivanteLtd/vue-storefront/issues/4559)
 - Fixed changing and deleting shipping details on MyAccount (#4499)
+- Corrected displayed the ratings stars on product page (#524)
 
 ## [1.0.2] - 03.07.2020
 

--- a/components/organisms/o-product-details.vue
+++ b/components/organisms/o-product-details.vue
@@ -141,7 +141,7 @@ export default {
         author: review.nickname,
         date: review.created_at,
         message: `${review.title}: ${review.detail}`,
-        rating: 1 // TODO: remove hardcode
+        rating: review.ratings.length > 0 ? review.ratings[0].value : 1
       }))
     },
     availability () {


### PR DESCRIPTION
### Related Issues

Closes #524 

### Short Description and Why It's Useful
Will loads actual review from ElasticSearch.

### Screenshots of Visual Changes before/after (If There Are Any)
Before:
<img width="629" alt="Снимок экрана 2020-10-20 в 18 18 30" src="https://user-images.githubusercontent.com/414067/96602573-37174180-1304-11eb-9272-856078d5bc30.png">

After:
<img width="621" alt="Снимок экрана 2020-10-20 в 18 30 05" src="https://user-images.githubusercontent.com/414067/96602639-46968a80-1304-11eb-9d28-d4a91526150b.png">


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)