### PR TITLE
Fixed: Closing of menu on clicking the profile icon on Mobile(#526)

### DIFF
--- a/components/organisms/o-bottom-navigation.vue
+++ b/components/organisms/o-bottom-navigation.vue
@@ -90,6 +90,7 @@ export default {
       this.$store.commit('ui/setSearchpanel', !this.isSearchPanelVisible)
     },
     goToAccount () {
+      this.$store.commit('ui/closeMenu')
       if (this.isLoggedIn) {
         this.$router.push(this.localizedRoute('/my-account'))
       } else {


### PR DESCRIPTION
Called "ui/closeMenu" in the function for navigating to profile in the bottom navigation.

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #526 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Menu should get close on clicking any link on bottom navigation

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before

![closemenubefore](https://user-images.githubusercontent.com/8766155/97081916-46a7ca80-1623-11eb-8ee6-486e0c5fcf8f.gif)


After

![closemenuafter](https://user-images.githubusercontent.com/8766155/97081920-4d364200-1623-11eb-9309-146313bf4509.gif)



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-capybara/blob/master/CONTRIBUTING.md)